### PR TITLE
refactor: Clean code, atomic design, component reusability

### DIFF
--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -1,0 +1,51 @@
+---
+description: Clean code, atomic design, and component reusability standards
+globs: "**/*.tsx, **/components/**/*.ts"
+alwaysApply: false
+---
+
+# Code Quality Standards
+
+## 1. Clean Code
+
+- **Single responsibility** – One component/function per concern. Split large components into focused subcomponents.
+- **Small units** – Functions under ~30 lines; components under ~150 lines.
+- **Naming** – Descriptive names; avoid abbreviations.
+- **Avoid duplication** – Extract repeated logic into shared utils or hooks.
+
+```tsx
+// BAD: 300-line component doing layout + charts + metrics + engagement
+function InstagramSection({ data }) { /* ... */ }
+
+// GOOD: Split into focused subcomponents
+function InstagramSection({ data }) {
+  return (
+    <>
+      <KeyInsightsRow data={data} />
+      <ReportSection title="Audience"><InstagramMetricsRow data={data} /></ReportSection>
+      <EngagementSection data={data} />
+    </>
+  );
+}
+```
+
+## 2. Atomic Design
+
+See `components/ui/README.md` for taxonomy.
+
+| Level | Location | Examples |
+|-------|----------|----------|
+| Atoms | `ui/` | Button, Input, Badge, Typography |
+| Molecules | `ui/` | StatBlock, FeeLineItem, LineChartCard, ComparisonMetricBlock |
+| Organisms | `landing/`, `istanbulmedic-connect/`, `common/` | HeroBanner, ClinicCard, Footer |
+
+- Put reusable building blocks in `ui/` as atoms or molecules.
+- Put feature-specific compositions in `landing/`, `istanbulmedic-connect/`, or `common/`.
+- Compose organisms from `ui/` primitives; do not inline markup that could be a molecule.
+
+## 3. Component Reusability
+
+- **Before adding** – Check if `ui/` already has a suitable component.
+- **Generic over specific** – Use props like `title`, `data`, `formatValue` instead of feature-specific strings.
+- **Extract when reused** – If a block appears in two or more places, extract to `ui/` or a shared subfolder.
+- **Feature subfolders** – Large organisms (e.g. InstagramIntelligenceSection) use subfolders like `profile/instagram/` for focused subcomponents.

--- a/app/globals.css
+++ b/app/globals.css
@@ -27,6 +27,12 @@
 
   --radius: 0.75rem;
 
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+
   --font-sans: Inter, system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
@@ -57,6 +63,12 @@
   --border: 0 0% 25.098%;
   --input: 0 0% 25.098%;
   --ring: 217.2193 91.2195% 59.8039%;
+
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
 }
 
 @theme inline {

--- a/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
+++ b/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
@@ -11,6 +11,7 @@ import { TransparencySection } from "./TransparencySection"
 import { AIInsightsSection } from "./AIInsightsSection"
 import { ReviewsSection } from "./ReviewsSection"
 import { CommunitySignalsSection } from "./CommunitySignalsSection"
+import { InstagramIntelligenceSection } from "./InstagramIntelligenceSection"
 import { LocationInfoSection } from "./LocationInfoSection"
 import { SummarySidebar } from "./SummarySidebar"
 
@@ -226,6 +227,41 @@ export const ClinicProfilePage = ({ clinicId, onBack }: ClinicProfilePageProps) 
         airportTransfer: true,
       },
     },
+    instagramIntelligence: {
+      profileUrl: "https://instagram.com/istanbulhaircenter",
+      username: "istanbulhaircenter",
+      fullName: "Istanbul Hair Center",
+      biography:
+        "Leading hair transplant clinic in Istanbul. Premium FUE & DHI specialists with 15+ years experience. Natural results. International patients welcome.",
+      followersCount: 12500,
+      postsCount: 342,
+      verified: true,
+      isBusinessAccount: true,
+      businessCategoryName: "Medical & Health",
+      externalUrls: [
+        "https://linktr.ee/istanbulhaircenter",
+        "https://istanbulhaircenter.com",
+      ],
+      extracted: {
+        positioningClaims: [
+          "Premium FUE",
+          "DHI specialists",
+          "15+ years experience",
+        ],
+        servicesClaimed: [
+          "Hair transplant",
+          "Beard transplant",
+          "PRP therapy",
+        ],
+        geographyClaimed: ["Istanbul", "Turkey", "Europe"],
+        languagesClaimed: ["English", "Turkish", "Arabic", "German"],
+        addressText: "Halaskargazi Cad. No: 124, Şişli",
+        websiteCandidates: ["https://istanbulhaircenter.com"],
+        linkAggregatorDetected: "linktr.ee",
+      },
+      firstSeenAt: "2025-01-15T00:00:00Z",
+      lastSeenAt: "2026-02-01T00:00:00Z",
+    },
   }
 
   return (
@@ -291,6 +327,10 @@ export const ClinicProfilePage = ({ clinicId, onBack }: ClinicProfilePageProps) 
           <CommunitySignalsSection
             posts={clinicData.communitySignals.posts}
             summary={clinicData.communitySignals.summary}
+          />
+
+          <InstagramIntelligenceSection
+            data={clinicData.instagramIntelligence}
           />
 
           <LocationInfoSection

--- a/components/istanbulmedic-connect/profile/CommunitySignalsSection.tsx
+++ b/components/istanbulmedic-connect/profile/CommunitySignalsSection.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { useState } from "react"
-import { ExternalLink, ChevronDown, ChevronUp } from "lucide-react"
+import { ChevronDown, ChevronUp, ExternalLink } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { StatBlock } from "@/components/ui/stat-block"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
 import { SOCIAL_LOGO_MAP, SOURCE_LABEL, type PostSource } from "@/lib/social-icons"
 
@@ -34,20 +35,10 @@ interface CommunitySignalsSectionProps {
 }
 
 export const CommunitySignalsSection = ({ posts, summary }: CommunitySignalsSectionProps) => {
-  const [activeFilter, setActiveFilter] = useState<PostSource | "all">("all")
   const [isExpanded, setIsExpanded] = useState(false)
 
   // Get unique sources present in posts
   const uniqueSources = Array.from(new Set(posts.map(p => p.source)))
-
-  // Filter posts
-  const filteredPosts = activeFilter === "all"
-    ? posts
-    : posts.filter(p => p.source === activeFilter)
-
-  // Pagination logic (show 4 by default - 2x2 grid feels better than 3)
-  const visiblePosts = isExpanded ? filteredPosts : filteredPosts.slice(0, 4)
-  const hasHiddenPosts = filteredPosts.length > 4
 
   return (
     <Card id="community" variant="profile" className="scroll-mt-32">
@@ -55,7 +46,7 @@ export const CommunitySignalsSection = ({ posts, summary }: CommunitySignalsSect
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h2 className="im-heading-2 text-foreground">Community Signals</h2>
-            <p className="text-base text-muted-foreground">
+            <p className="im-text-body im-text-muted">
               Mentions from social platforms and community discussions.
             </p>
           </div>
@@ -71,7 +62,7 @@ export const CommunitySignalsSection = ({ posts, summary }: CommunitySignalsSect
       <CardContent className="space-y-4">
         {/* Sentiment Badges */}
         <div className="flex flex-wrap items-center gap-2 mb-4">
-          <Badge className="bg-[#17375B] text-white hover:bg-[#17375B]/90">
+          <Badge className="bg-[var(--im-color-primary)] text-white hover:bg-[var(--im-color-primary)]/90">
             Sentiment: <span className="ml-1 font-bold">{summary.sentiment}</span>
           </Badge>
           {summary.commonThemes.map((theme) => (
@@ -83,122 +74,130 @@ export const CommunitySignalsSection = ({ posts, summary }: CommunitySignalsSect
 
         <Separator />
 
-        {/* Filter Bar */}
-        <div className="flex flex-wrap items-center gap-2 pt-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => { setActiveFilter("all"); setIsExpanded(false); }}
-            className={cn(
-              "rounded-full border transition-all shadow-none",
-              activeFilter === "all"
-                ? "bg-[#17375B] border-[#17375B] text-white hover:bg-[#17375B]/90"
-                : "bg-transparent border-input hover:border-[#17375B] hover:text-[#17375B]"
-            )}
-          >
-            All
-          </Button>
-          {uniqueSources.map(source => (
-            <Button
-              key={source}
-              variant="outline"
-              size="sm"
-              onClick={() => { setActiveFilter(source); setIsExpanded(false); }}
+        {/* Filter Tabs - same component as Social Presence */}
+        <Tabs defaultValue="all" className="w-full">
+          <TabsList className="mb-4 flex h-auto w-fit flex-wrap gap-2 rounded-full border-0 bg-transparent p-0">
+            <TabsTrigger
+              value="all"
               className={cn(
-                "rounded-full border transition-all gap-1.5 shadow-none",
-                activeFilter === source
-                  ? "bg-[#17375B] border-[#17375B] text-white hover:bg-[#17375B]/90"
-                  : "bg-transparent border-input hover:border-[#17375B] hover:text-[#17375B]"
+                "inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50",
+                "data-[state=active]:border-transparent data-[state=active]:bg-[#17375B] data-[state=active]:text-white data-[state=active]:hover:bg-[#17375B]"
               )}
             >
-              {activeFilter === source ? SOCIAL_LOGO_MAP[source] : (
-                <span className="opacity-70">{SOCIAL_LOGO_MAP[source]}</span>
-              )}
-              {SOURCE_LABEL[source]}
-            </Button>
-          ))}
-        </div>
+              All
+            </TabsTrigger>
+            {uniqueSources.map((source) => (
+              <TabsTrigger
+                key={source}
+                value={source}
+                className={cn(
+                  "inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50",
+                  "data-[state=active]:border-transparent data-[state=active]:bg-[#17375B] data-[state=active]:text-white data-[state=active]:hover:bg-[#17375B] [&[data-state=active]_svg]:!text-white"
+                )}
+              >
+                {SOCIAL_LOGO_MAP[source]}
+                {SOURCE_LABEL[source]}
+              </TabsTrigger>
+            ))}
+          </TabsList>
 
-        {/* Posts List - Grid Layout */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
-          {visiblePosts.map((post, idx) => (
-            <div key={`${post.source}-${idx}-${post.date}`} className="rounded-xl bg-muted/5 p-4 border border-border/40 hover:border-border/80 transition-colors flex flex-col h-full">
-              <div className="flex flex-col gap-3 flex-1">
-                {/* Header: Logo, Author, Meta */}
-                <div className="flex items-start justify-between">
-                  <div className="flex items-start gap-3">
-                    <div className="p-2 bg-white rounded-full shadow-sm border border-border/20 mt-0.5 shrink-0">
-                      {SOCIAL_LOGO_MAP[post.source]}
-                    </div>
-                    <div className="flex flex-col min-w-0">
-                      <span className="font-semibold text-sm text-foreground truncate max-w-[150px]">
-                        {post.author}
-                      </span>
-                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                        <span className="font-medium text-foreground/80">{SOURCE_LABEL[post.source]}</span>
-                        <span>•</span>
-                        <span>{post.date}</span>
+          {["all", ...uniqueSources].map((source) => {
+            const filteredPosts =
+              source === "all"
+                ? posts
+                : posts.filter((p) => p.source === source)
+            const visiblePosts = isExpanded ? filteredPosts : filteredPosts.slice(0, 4)
+            const hasHiddenPosts = filteredPosts.length > 4
+
+            return (
+              <TabsContent key={source} value={source} className="mt-0">
+                <div className="grid grid-cols-1 gap-4 pt-0 md:grid-cols-2">
+                    {visiblePosts.map((post, idx) => (
+                      <div
+                        key={`${post.source}-${idx}-${post.date}`}
+                        className="flex h-full flex-col rounded-xl border border-border/40 bg-muted/5 p-4 transition-colors hover:border-border/80"
+                      >
+                        <div className="flex flex-1 flex-col gap-3">
+                          <div className="flex items-start justify-between">
+                            <div className="flex items-start gap-3">
+                              <div className="mt-0.5 shrink-0 rounded-full border border-border/20 bg-white p-2 shadow-sm">
+                                {SOCIAL_LOGO_MAP[post.source]}
+                              </div>
+                              <div className="flex min-w-0 flex-col">
+                                <span className="truncate text-sm font-semibold text-foreground max-w-[150px]">
+                                  {post.author}
+                                </span>
+                                <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                                  <span className="font-medium text-foreground/80">
+                                    {SOURCE_LABEL[post.source]}
+                                  </span>
+                                  <span>•</span>
+                                  <span>{post.date}</span>
+                                </div>
+                              </div>
+                            </div>
+                            {post.url && post.url !== "#" ? (
+                              <Button
+                                asChild
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 shrink-0 px-2 text-muted-foreground hover:text-foreground"
+                              >
+                                <a
+                                  href={post.url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  aria-label="Open source"
+                                  className="inline-flex items-center gap-1.5"
+                                >
+                                  <ExternalLink className="h-3.5 w-3.5" />
+                                </a>
+                              </Button>
+                            ) : null}
+                          </div>
+                          <p className="pl-[3.5rem] im-text-body leading-relaxed im-text-muted line-clamp-4">
+                            {post.snippet}
+                          </p>
+                        </div>
                       </div>
-                    </div>
+                    ))}
                   </div>
 
-                  {post.url && post.url !== "#" ? (
-                    <Button asChild variant="ghost" size="sm" className="h-7 px-2 text-muted-foreground hover:text-foreground shrink-0">
-                      <a
-                        href={post.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label="Open source"
-                        className="inline-flex items-center gap-1.5"
+                  {filteredPosts.length === 0 && (
+                    <div className="py-8 text-center text-muted-foreground">
+                      No mentions found for this category.
+                    </div>
+                  )}
+
+                  {hasHiddenPosts && (
+                    <div className="pt-2">
+                      <Button
+                        variant="link"
+                        className="w-full justify-start gap-2 text-foreground underline-offset-4 hover:text-[#3EBBB7]"
+                        onClick={() => setIsExpanded(true)}
                       >
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </a>
-                    </Button>
-                  ) : null}
-                </div>
+                        <ChevronDown className="h-4 w-4" />
+                        View all {filteredPosts.length} mentions
+                      </Button>
+                    </div>
+                  )}
 
-                {/* Content */}
-                <p className="text-base leading-relaxed text-muted-foreground pl-[3.5rem] line-clamp-4">
-                  {post.snippet}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {filteredPosts.length === 0 && (
-          <div className="text-center py-8 text-muted-foreground">
-            No mentions found for this category.
-          </div>
-        )}
-
-        {/* View All / Expansion Button */}
-        {hasHiddenPosts && (
-          <div className="pt-2">
-            <Button
-              variant="link"
-              className="w-full gap-2 text-foreground hover:text-[#3EBBB7] justify-start underline-offset-4"
-              onClick={() => setIsExpanded(true)}
-            >
-              <ChevronDown className="h-4 w-4" />
-              View all {filteredPosts.length} mentions
-            </Button>
-          </div>
-        )}
-
-        {isExpanded && filteredPosts.length > 4 && (
-          <div className="pt-2">
-            <Button
-              variant="link"
-              className="w-full gap-2 text-foreground hover:text-[#3EBBB7] justify-start underline-offset-4"
-              onClick={() => setIsExpanded(false)}
-            >
-              <ChevronUp className="h-4 w-4" />
-              Show less
-            </Button>
-          </div>
-        )}
-
+                  {isExpanded && filteredPosts.length > 4 && (
+                    <div className="pt-2">
+                      <Button
+                        variant="link"
+                        className="w-full justify-start gap-2 text-foreground underline-offset-4 hover:text-[#3EBBB7]"
+                        onClick={() => setIsExpanded(false)}
+                      >
+                        <ChevronUp className="h-4 w-4" />
+                        Show less
+                      </Button>
+                    </div>
+                  )}
+                </TabsContent>
+              )
+            })}
+          </Tabs>
       </CardContent>
     </Card>
   )

--- a/components/istanbulmedic-connect/profile/InstagramIntelligenceSection.tsx
+++ b/components/istanbulmedic-connect/profile/InstagramIntelligenceSection.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { Facebook, Instagram, Music2 } from "lucide-react"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { EmptyState } from "@/components/ui/empty-state"
+import {
+  PlatformPillTabs,
+  type PlatformPillTabItem,
+} from "@/components/ui/platform-pill-tabs"
+import type { InstagramIntelligenceVM } from "@/components/istanbulmedic-connect/types"
+import { InstagramTabContent } from "./instagram/InstagramTabContent"
+
+const PLATFORM_TABS: PlatformPillTabItem[] = [
+  {
+    value: "instagram",
+    label: "Instagram",
+    icon: Instagram,
+    iconColor: "text-[#E1306C]",
+  },
+  {
+    value: "tiktok",
+    label: "TikTok",
+    icon: Music2,
+    iconColor: "text-black",
+  },
+  {
+    value: "facebook",
+    label: "Facebook",
+    icon: Facebook,
+    iconColor: "text-[#1877F2]",
+  },
+]
+
+export interface InstagramIntelligenceSectionProps {
+  data?: InstagramIntelligenceVM | null
+}
+
+export const InstagramIntelligenceSection = ({
+  data,
+}: InstagramIntelligenceSectionProps) => {
+  return (
+    <Card id="instagram-intel" variant="profile" className="scroll-mt-32">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="im-heading-2 text-foreground">
+              Social Presence &amp; Brand Signals
+            </h2>
+            <p className="im-text-body im-text-muted">
+              Signals from the clinic&apos;s social media profiles.
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-6 pt-4">
+        <PlatformPillTabs
+          defaultValue="instagram"
+          tabs={PLATFORM_TABS}
+          listClassName="mb-6"
+        >
+          <PlatformPillTabs.Content value="instagram" className="mt-0">
+            <InstagramTabContent data={data} />
+          </PlatformPillTabs.Content>
+          <PlatformPillTabs.Content value="tiktok" className="mt-0">
+            <EmptyState
+              title="TikTok data is not available yet."
+              description="Connect this profile to view insights."
+            />
+          </PlatformPillTabs.Content>
+          <PlatformPillTabs.Content value="facebook" className="mt-0">
+            <EmptyState
+              title="Facebook data is not available yet."
+              description="Connect this profile to view insights."
+            />
+          </PlatformPillTabs.Content>
+        </PlatformPillTabs>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/istanbulmedic-connect/profile/SectionNav.tsx
+++ b/components/istanbulmedic-connect/profile/SectionNav.tsx
@@ -15,6 +15,7 @@ const SECTIONS: Section[] = [
   { id: "transparency", label: "Safety" },
   { id: "ai-insights", label: "AI Insights" },
   { id: "reviews", label: "Reviews" },
+  { id: "instagram-intel", label: "Social" },
   { id: "location", label: "Location" },
 ]
 

--- a/components/istanbulmedic-connect/profile/instagram/EngagementSection.tsx
+++ b/components/istanbulmedic-connect/profile/instagram/EngagementSection.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { ComparisonMetricBlock } from "@/components/ui/comparison-metric-block"
+import { ReportSection } from "@/components/ui/report-section"
+import type { InstagramIntelligenceVM } from "@/components/istanbulmedic-connect/types"
+
+const ENGAGEMENT_METRICS = [
+  {
+    key: "engagementTotalPerPost" as const,
+    title: "Engagement Total per Post",
+    description:
+      "Higher engagement totals help more people see your content. When it comes to likes and comments, more is always better.",
+    formatValue: (v: number) => v.toFixed(2),
+    getClinicValue: (eng: InstagramIntelligenceVM["engagement"]) =>
+      eng?.engagementTotalPerPost ?? 0.67,
+    getBenchmarkValue: (b: NonNullable<InstagramIntelligenceVM["engagement"]>["benchmark"]) =>
+      b?.engagementTotalPerPost ?? 360,
+  },
+  {
+    key: "engagementRate" as const,
+    title: "Engagement Rate",
+    description:
+      "Engagement rate shows what percentage of your followers interact with your posts. Higher rates indicate stronger audience connection.",
+    formatValue: (v: number) => {
+      const pct = v * 100
+      return pct < 0.01 ? `<${pct.toFixed(3)}%` : `${pct.toFixed(2)}%`
+    },
+    getClinicValue: (eng: InstagramIntelligenceVM["engagement"]) =>
+      eng?.engagementRate ?? 0.00004,
+    getBenchmarkValue: (b: NonNullable<InstagramIntelligenceVM["engagement"]>["benchmark"]) =>
+      (b?.engagementRate ?? 0.47) / 100,
+  },
+  {
+    key: "commentsPerPost" as const,
+    title: "Comments per Post",
+    description:
+      "Comments indicate deeper engagement than likes. More comments often mean your content sparks conversation.",
+    formatValue: (v: number) => v.toFixed(2),
+    getClinicValue: (eng: InstagramIntelligenceVM["engagement"]) =>
+      eng?.commentsPerPost ?? 0.6,
+    getBenchmarkValue: (b: NonNullable<InstagramIntelligenceVM["engagement"]>["benchmark"]) =>
+      b?.commentsPerPost ?? 12,
+  },
+] as const
+
+export function EngagementSection({ data }: { data: InstagramIntelligenceVM }) {
+  const eng = data.engagement
+  const benchmark = eng?.benchmark ?? {}
+
+  return (
+    <ReportSection
+      title="Engagement"
+      description="Engagement measures how much your followers interact with your content. You can have all the followers in the world, but if they don't engage with your content, your social media efforts won't pay off."
+    >
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {ENGAGEMENT_METRICS.map((m) => (
+          <ComparisonMetricBlock
+            key={m.key}
+            title={m.title}
+            description={m.description}
+            primaryValue={m.getClinicValue(eng)}
+            benchmarkValue={m.getBenchmarkValue(benchmark)}
+            formatValue={m.formatValue}
+          />
+        ))}
+      </div>
+    </ReportSection>
+  )
+}

--- a/components/istanbulmedic-connect/profile/instagram/InstagramMetricsRow.tsx
+++ b/components/istanbulmedic-connect/profile/instagram/InstagramMetricsRow.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { ExternalLink, Image, Tag, Users } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { formatNumber, truncate } from "@/lib/utils"
+import type { InstagramIntelligenceVM } from "@/components/istanbulmedic-connect/types"
+
+export function InstagramMetricsRow({ data }: { data: InstagramIntelligenceVM }) {
+  const metrics = [
+    {
+      label: "Followers",
+      value: formatNumber(data.followersCount),
+      icon: Users,
+    },
+    {
+      label: "Posts",
+      value: formatNumber(data.postsCount),
+      icon: Image,
+    },
+    {
+      label: "Category",
+      value: truncate(data.businessCategoryName, 14),
+      icon: Tag,
+    },
+    ...(data.externalUrls?.length
+      ? [
+          {
+            label: "Links",
+            value: String(data.externalUrls.length),
+            icon: ExternalLink,
+          },
+        ]
+      : []),
+  ]
+
+  if (metrics.length === 0) return null
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+      {metrics.map((m, i) => {
+        const Icon = m.icon
+        return (
+          <div
+            key={m.label}
+            className={cn(
+              "flex flex-col items-center px-4 py-3",
+              i > 0 && "border-l border-border/60"
+            )}
+          >
+            <div className="text-center text-xs font-medium text-muted-foreground">
+              {m.label}
+            </div>
+            <div className="mt-1 text-center text-2xl font-bold text-foreground">
+              {m.value ?? "—"}
+            </div>
+            <Icon className="mt-2 h-4 w-4 shrink-0 text-muted-foreground" />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/istanbulmedic-connect/profile/instagram/InstagramTabContent.tsx
+++ b/components/istanbulmedic-connect/profile/instagram/InstagramTabContent.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { BarChartCard } from "@/components/ui/bar-chart-card"
+import { EmptyState } from "@/components/ui/empty-state"
+import { LineChartCard } from "@/components/ui/line-chart-card"
+import { ReportSection } from "@/components/ui/report-section"
+import type { InstagramIntelligenceVM } from "@/components/istanbulmedic-connect/types"
+import {
+  formatChartMonth,
+  formatChartMonthShort,
+  formatDate,
+} from "@/lib/utils"
+import { Calendar, LineChart as LineChartIcon } from "lucide-react"
+import { EngagementSection } from "./EngagementSection"
+import { InstagramMetricsRow } from "./InstagramMetricsRow"
+import { KeyInsightsRow } from "./KeyInsightsRow"
+
+const DEFAULT_FOLLOWER_HISTORY = [
+  { month: "Jul '25", followers: 7800 },
+  { month: "Aug '25", followers: 9000 },
+  { month: "Sep '25", followers: 9800 },
+  { month: "Oct '25", followers: 10600 },
+  { month: "Nov '25", followers: 11400 },
+  { month: "Dec '25", followers: 12200 },
+  { month: "Jan '26", followers: 13200 },
+]
+
+const DEFAULT_POST_ACTIVITY = [
+  { month: "Jul", posts: 42 },
+  { month: "Aug", posts: 47 },
+  { month: "Sep", posts: 51 },
+  { month: "Oct", posts: 45 },
+  { month: "Nov", posts: 55 },
+  { month: "Dec", posts: 48 },
+  { month: "Jan", posts: 56 },
+]
+
+const followerChartConfig = {
+  followers: {
+    label: "Followers",
+    color: "hsl(var(--primary))",
+  },
+}
+
+const postChartConfig = {
+  posts: {
+    label: "Posts",
+    color: "hsl(263 70% 50%)",
+  },
+}
+
+export function InstagramTabContent({
+  data,
+}: {
+  data?: InstagramIntelligenceVM | null
+}) {
+  if (!data?.username && !data?.profileUrl) {
+    return (
+      <EmptyState
+        title="Instagram data is not available yet."
+        description="Connect this profile to view insights."
+      />
+    )
+  }
+
+  const followerData =
+    (data.followerHistory?.length ?? 0) > 0
+      ? (data.followerHistory ?? []).map((d) => ({
+          month: formatChartMonth(d.month),
+          followers: d.followers,
+        }))
+      : DEFAULT_FOLLOWER_HISTORY
+
+  const postData =
+    (data.postActivityHistory?.length ?? 0) > 0
+      ? (data.postActivityHistory ?? []).map((d) => ({
+          month: formatChartMonthShort(d.month),
+          posts: d.posts,
+        }))
+      : DEFAULT_POST_ACTIVITY
+
+  return (
+    <div className="space-y-8">
+      {data.lastSeenAt && (
+        <div className="im-text-body-xs im-text-muted">
+          Last updated: {formatDate(data.lastSeenAt)}
+        </div>
+      )}
+      <KeyInsightsRow data={data} />
+      <ReportSection
+        title="Audience"
+        description="Who's behind the profile. Follower count and post volume signal reach and activity level."
+      >
+        <InstagramMetricsRow data={data} />
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <LineChartCard
+            title="Follower Growth"
+            icon={LineChartIcon}
+            data={followerData}
+            dataKeyX="month"
+            dataKeyY="followers"
+            config={followerChartConfig}
+          />
+          <BarChartCard
+            title="Posting Activity"
+            icon={Calendar}
+            data={postData}
+            dataKeyX="month"
+            dataKeyY="posts"
+            config={postChartConfig}
+          />
+        </div>
+      </ReportSection>
+      <EngagementSection data={data} />
+    </div>
+  )
+}

--- a/components/istanbulmedic-connect/profile/instagram/KeyInsightsRow.tsx
+++ b/components/istanbulmedic-connect/profile/instagram/KeyInsightsRow.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { MessageCircle, Trophy, Users } from "lucide-react"
+import { cn, formatNumber } from "@/lib/utils"
+import type { InstagramIntelligenceVM } from "@/components/istanbulmedic-connect/types"
+
+export function KeyInsightsRow({ data }: { data: InstagramIntelligenceVM }) {
+  const eng = data.engagement
+  const benchmark = eng?.benchmark ?? {}
+
+  const engagementPerPost = eng?.engagementTotalPerPost ?? 0.67
+  const benchmarkEngagement = benchmark.engagementTotalPerPost ?? 360
+  const engagementMultiple =
+    engagementPerPost > 0 ? (benchmarkEngagement / engagementPerPost).toFixed(1) : null
+
+  const followers = data.followersCount ?? 0
+  const commentsPerPost = eng?.commentsPerPost ?? 0.6
+  const benchmarkComments = benchmark.commentsPerPost ?? 12
+  const commentsMultiple =
+    commentsPerPost > 0 ? (benchmarkComments / commentsPerPost).toFixed(1) : null
+
+  const insights = [
+    {
+      icon: Trophy,
+      text:
+        engagementMultiple && parseFloat(engagementMultiple) > 1
+          ? `Benchmark averages ${engagementMultiple}x more engagement per post than this profile. Room to grow.`
+          : `Strong engagement: this profile averages ${engagementPerPost.toFixed(2)} engagement per post.`,
+    },
+    {
+      icon: Users,
+      text: followers > 0
+        ? `This profile has ${formatNumber(followers)} followers, building an audience for reach and visibility.`
+        : `Audience metrics will appear as data is collected.`,
+    },
+    {
+      icon: MessageCircle,
+      text:
+        commentsMultiple && parseFloat(commentsMultiple) > 1
+          ? `Benchmark receives ${commentsMultiple}x more comments per post. This profile averages ${commentsPerPost.toFixed(2)} comments per post.`
+          : `Crushing it! This profile averages ${commentsPerPost.toFixed(2)} comments per post.`,
+    },
+  ]
+
+  return (
+    <section>
+      <h3 className="mb-4 text-center text-base font-semibold text-muted-foreground">
+        Key Insights
+      </h3>
+      <div className="grid grid-cols-1 gap-6 border-y border-border/60 py-6 md:grid-cols-3">
+        {insights.map((item, i) => {
+          const Icon = item.icon
+          return (
+            <div
+              key={i}
+              className={cn(
+                "flex flex-col gap-3 md:flex-row",
+                i > 0 && "md:border-l md:border-border/60 md:pl-6"
+              )}
+            >
+              <Icon className="h-5 w-5 shrink-0 text-muted-foreground" />
+              <p className="im-text-body-sm leading-relaxed text-foreground">
+                {item.text}
+              </p>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/components/istanbulmedic-connect/types.ts
+++ b/components/istanbulmedic-connect/types.ts
@@ -24,3 +24,56 @@ export interface FilterState {
   aiMatchScore: number
 }
 
+/** View model for Instagram intelligence data (from import results / DB) */
+export interface InstagramIntelligenceVM {
+  profileUrl?: string
+  username?: string
+  fullName?: string
+  biography?: string
+
+  followersCount?: number
+  postsCount?: number
+  verified?: boolean
+  isBusinessAccount?: boolean
+  businessCategoryName?: string
+
+  externalUrls?: string[]
+
+  extracted?: {
+    positioningClaims?: string[]
+    servicesClaimed?: string[]
+    languagesClaimed?: string[]
+    geographyClaimed?: string[]
+    addressText?: string
+    websiteCandidates?: string[]
+    linkAggregatorDetected?: string
+  }
+
+  firstSeenAt?: string
+  lastSeenAt?: string
+
+  /** Monthly follower counts (e.g. [{ month: "2025-07", followers: 7800 }]) */
+  followerHistory?: { month: string; followers: number }[]
+  /** Monthly post counts (e.g. [{ month: "2025-07", posts: 42 }]) */
+  postActivityHistory?: { month: string; posts: number }[]
+
+  /** Engagement metrics (clinic vs benchmark) */
+  engagement?: {
+    engagementTotalPerPost?: number
+    engagementRate?: number
+    commentsPerPost?: number
+    benchmark?: {
+      engagementTotalPerPost?: number
+      engagementRate?: number
+      commentsPerPost?: number
+    }
+  }
+
+  confidence?: {
+    positioning?: number
+    services?: number
+    languages?: number
+    geography?: number
+    contact?: number
+  }
+}

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -45,13 +45,20 @@ Simple groups of atoms functioning together as a unit.
 | `card.tsx` | Card, CardHeader, CardContent, CardFooter | Layout composition |
 | `dialog.tsx` | Dialog and parts | Modal composition |
 | `carousel.tsx` | Carousel | Slider + navigation |
+| `chart.tsx` | ChartContainer, ChartTooltip, ChartTooltipContent | Recharts integration |
+| `empty-state.tsx` | EmptyState | Placeholder for missing data |
+| `platform-pill-tabs.tsx` | PlatformPillTabs | Platform-switching tabs (e.g. Instagram, TikTok) |
+| `report-section.tsx` | ReportSection | Title + description + children section |
+| `comparison-metric-block.tsx` | ComparisonMetricBlock | Primary vs benchmark value with bar visualization |
+| `line-chart-card.tsx` | LineChartCard | Bordered card + line chart (e.g. follower growth) |
+| `bar-chart-card.tsx` | BarChartCard | Bordered card + bar chart (e.g. posting activity) |
 
 ## Organisms
 
 Organisms live outside this directory:
 
 - **Landing:** `components/landing/` – HeroBanner, FeatureCard, LandingSection, PrecisionClinicMatching, etc.
-- **Connect:** `components/istanbulmedic-connect/` – ClinicCard, FilterDialog, SummarySidebar, TopNav, profile sections
+- **Connect:** `components/istanbulmedic-connect/` – ClinicCard, FilterDialog, SummarySidebar, TopNav, profile sections (including `profile/instagram/` subcomponents for InstagramIntelligenceSection)
 - **Common:** `components/common/` – Header, Logo, LanguageSelector
 
 ## Templates

--- a/components/ui/bar-chart-card.tsx
+++ b/components/ui/bar-chart-card.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+export interface BarChartCardProps<T extends Record<string, unknown>> {
+  /** Chart title */
+  title: string
+  /** Icon shown next to title */
+  icon?: LucideIcon
+  /** Data array, e.g. [{ month: "Jan", posts: 42 }] */
+  data: T[]
+  /** Key for X axis (e.g. "month") */
+  dataKeyX: keyof T
+  /** Key for bars (e.g. "posts") */
+  dataKeyY: keyof T
+  /** Chart config for tooltip/legend */
+  config: ChartConfig
+  /** Bar fill color */
+  barColor?: string
+  className?: string
+}
+
+export function BarChartCard<T extends Record<string, unknown>>({
+  title,
+  icon: Icon,
+  data,
+  dataKeyX,
+  dataKeyY,
+  config,
+  barColor = "hsl(263 70% 50%)",
+  className,
+}: BarChartCardProps<T>) {
+  return (
+    <div className={cn("rounded-xl border border-border/60 bg-muted/5 p-4", className)}>
+      <div className="mb-4 flex items-center gap-2">
+        {Icon && <Icon className="h-5 w-5 shrink-0 text-[#7c3aed]" />}
+        <h4 className="text-base font-semibold text-foreground">{title}</h4>
+      </div>
+      <ChartContainer config={config} className="min-h-[200px] w-full">
+        <BarChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+          <XAxis
+            dataKey={String(dataKeyX)}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Bar
+            dataKey={String(dataKeyY)}
+            fill={barColor}
+            radius={[4, 4, 0, 0]}
+          />
+        </BarChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,0 +1,369 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >["children"]
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: "line" | "dot" | "dashed"
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn("font-medium", labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot"
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          className
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload
+            .filter((item) => item.type !== "none")
+            .map((item, index) => {
+              const key = `${nameKey || item.name || item.dataKey || "value"}`
+              const itemConfig = getPayloadConfigFromPayload(config, item, key)
+              const indicatorColor = color || item.payload.fill || item.color
+
+              return (
+                <div
+                  key={item.dataKey}
+                  className={cn(
+                    "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                    indicator === "dot" && "items-center"
+                  )}
+                >
+                  {formatter && item?.value !== undefined && item.name ? (
+                    formatter(item.value, item.name, item, index, item.payload)
+                  ) : (
+                    <>
+                      {itemConfig?.icon ? (
+                        <itemConfig.icon />
+                      ) : (
+                        !hideIndicator && (
+                          <div
+                            className={cn(
+                              "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                              {
+                                "h-2.5 w-2.5": indicator === "dot",
+                                "w-1": indicator === "line",
+                                "w-0 border-[1.5px] border-dashed bg-transparent":
+                                  indicator === "dashed",
+                                "my-0.5": nestLabel && indicator === "dashed",
+                              }
+                            )}
+                            style={
+                              {
+                                "--color-bg": indicatorColor,
+                                "--color-border": indicatorColor,
+                              } as React.CSSProperties
+                            }
+                          />
+                        )
+                      )}
+                      <div
+                        className={cn(
+                          "flex flex-1 justify-between leading-none",
+                          nestLabel ? "items-end" : "items-center"
+                        )}
+                      >
+                        <div className="grid gap-1.5">
+                          {nestLabel ? tooltipLabel : null}
+                          <span className="text-muted-foreground">
+                            {itemConfig?.label || item.name}
+                          </span>
+                        </div>
+                        {item.value && (
+                          <span className="font-mono font-medium tabular-nums text-foreground">
+                            {item.value.toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )
+            })}
+        </div>
+      </div>
+    )
+  }
+)
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center justify-center gap-4",
+          verticalAlign === "top" ? "pb-3" : "pt-3",
+          className
+        )}
+      >
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item) => {
+            const key = `${nameKey || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+            return (
+              <div
+                key={item.value}
+                className={cn(
+                  "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+                )}
+              >
+                {itemConfig?.icon && !hideIcon ? (
+                  <itemConfig.icon />
+                ) : (
+                  <div
+                    className="h-2 w-2 shrink-0 rounded-[2px]"
+                    style={{
+                      backgroundColor: item.color,
+                    }}
+                  />
+                )}
+                {itemConfig?.label}
+              </div>
+            )
+          })}
+      </div>
+    )
+  }
+)
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/components/ui/comparison-metric-block.tsx
+++ b/components/ui/comparison-metric-block.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { type LucideIcon, Info, Shield } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface ComparisonMetricBlockProps {
+  /** Metric title */
+  title: string
+  /** Explanation shown below the title */
+  description: string
+  /** Primary value (e.g. "this profile") */
+  primaryValue: number
+  /** Comparison value (e.g. benchmark) */
+  benchmarkValue: number
+  /** Format numeric value for display */
+  formatValue: (v: number) => string
+  /** Label for primary row */
+  primaryLabel?: string
+  /** Label for benchmark row */
+  benchmarkLabel?: string
+  /** Icon for primary row */
+  primaryIcon?: LucideIcon
+  className?: string
+}
+
+export const ComparisonMetricBlock = ({
+  title,
+  description,
+  primaryValue,
+  benchmarkValue,
+  formatValue,
+  primaryLabel = "This profile",
+  benchmarkLabel = "Benchmark Average",
+  primaryIcon: PrimaryIcon = Shield,
+  className,
+}: ComparisonMetricBlockProps) => {
+  const maxVal = Math.max(primaryValue, benchmarkValue, 1)
+  const maxBarPx = 80
+  const primaryBarPx = maxVal > 0 ? Math.max((primaryValue / maxVal) * maxBarPx, 4) : 4
+  const benchmarkBarPx = maxVal > 0 ? Math.max((benchmarkValue / maxVal) * maxBarPx, 8) : 8
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center gap-2">
+        <span className="text-base font-semibold text-foreground">{title}</span>
+        <Info className="h-4 w-4 shrink-0 text-muted-foreground" aria-label="More info" />
+      </div>
+      <p className="im-text-body-sm im-text-muted">{description}</p>
+      <div className="space-y-3 rounded-xl border border-border/60 bg-muted/5 p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {PrimaryIcon && <PrimaryIcon className="h-4 w-4 shrink-0 text-foreground" />}
+            <span className="truncate im-text-body-sm im-text-muted">{primaryLabel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div
+              className="h-4 rounded bg-primary min-w-1"
+              style={{ width: `${primaryBarPx}px` }}
+            />
+            <span className="min-w-[4rem] text-right font-mono text-sm font-medium tabular-nums text-foreground">
+              {formatValue(primaryValue)}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="h-4 w-4 shrink-0 rounded bg-muted-foreground/30" />
+            <span className="truncate im-text-body-sm im-text-muted">{benchmarkLabel}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div
+              className="h-4 rounded bg-muted-foreground/40"
+              style={{ width: `${benchmarkBarPx}px` }}
+            />
+            <span className="min-w-[4rem] text-right font-mono text-sm font-medium tabular-nums text-foreground">
+              {formatValue(benchmarkValue)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface EmptyStateProps {
+  title?: string
+  description: string
+  className?: string
+}
+
+export const EmptyState = ({
+  title,
+  description,
+  className,
+}: EmptyStateProps) => {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[200px] flex-col items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/5 py-16 text-center",
+        className
+      )}
+    >
+      {title && (
+        <p className="im-text-body-sm im-text-muted">{title}</p>
+      )}
+      <p className={cn("im-text-body-xs im-text-muted", title && "mt-1")}>
+        {description}
+      </p>
+    </div>
+  )
+}

--- a/components/ui/line-chart-card.tsx
+++ b/components/ui/line-chart-card.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+import { formatNumber } from "@/lib/utils"
+import {
+  CartesianGrid,
+  Line,
+  LineChart as RechartsLineChart,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+export interface LineChartCardProps<T extends Record<string, unknown>> {
+  /** Chart title */
+  title: string
+  /** Icon shown next to title */
+  icon?: LucideIcon
+  /** Data array, e.g. [{ month: "Jan '25", followers: 1000 }] */
+  data: T[]
+  /** Key for X axis (e.g. "month") */
+  dataKeyX: keyof T
+  /** Key for Y axis / line (e.g. "followers") */
+  dataKeyY: keyof T
+  /** Chart config for tooltip/legend */
+  config: ChartConfig
+  /** Optional Y-axis formatter */
+  yAxisFormatter?: (v: number) => string
+  /** Color for the line */
+  lineColor?: string
+  className?: string
+}
+
+export function LineChartCard<T extends Record<string, unknown>>({
+  title,
+  icon: Icon,
+  data,
+  dataKeyX,
+  dataKeyY,
+  config,
+  yAxisFormatter = (v) => formatNumber(v),
+  lineColor = "hsl(var(--primary))",
+  className,
+}: LineChartCardProps<T>) {
+  return (
+    <div className={cn("rounded-xl border border-border/60 bg-muted/5 p-4", className)}>
+      <div className="mb-4 flex items-center gap-2">
+        {Icon && <Icon className="h-5 w-5 shrink-0 text-[#2563eb]" />}
+        <h4 className="text-base font-semibold text-foreground">{title}</h4>
+      </div>
+      <ChartContainer config={config} className="min-h-[200px] w-full">
+        <RechartsLineChart data={data} margin={{ top: 5, right: 5, left: 5, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+          <XAxis
+            dataKey={String(dataKeyX)}
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tickFormatter={(v) => yAxisFormatter(v)}
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Line
+            type="monotone"
+            dataKey={String(dataKeyY)}
+            stroke={lineColor}
+            strokeWidth={2}
+            dot={{ fill: lineColor, r: 4 }}
+          />
+        </RechartsLineChart>
+      </ChartContainer>
+    </div>
+  )
+}

--- a/components/ui/platform-pill-tabs.tsx
+++ b/components/ui/platform-pill-tabs.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import * as React from "react"
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+export interface PlatformPillTabItem {
+  value: string
+  label: string
+  icon?: React.ReactNode | LucideIcon
+  iconColor?: string
+}
+
+interface PlatformPillTabsProps {
+  defaultValue: string
+  tabs: PlatformPillTabItem[]
+  children: React.ReactNode
+  className?: string
+  listClassName?: string
+}
+
+const pillTriggerBase =
+  "inline-flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 im-text-body-sm font-medium text-foreground transition-colors hover:bg-muted/50"
+const pillTriggerActive =
+  "data-[state=active]:border-transparent data-[state=active]:bg-[var(--im-color-primary)] data-[state=active]:text-white data-[state=active]:hover:bg-[var(--im-color-primary)] [&[data-state=active]_svg]:!text-white"
+
+export const PlatformPillTabs = ({
+  defaultValue,
+  tabs,
+  children,
+  className,
+  listClassName,
+}: PlatformPillTabsProps) => {
+  return (
+    <Tabs defaultValue={defaultValue} className={cn("w-full", className)}>
+      <TabsList
+        className={cn(
+          "mb-4 flex h-auto w-fit flex-wrap gap-2 rounded-full border-0 bg-transparent p-0",
+          listClassName
+        )}
+      >
+        {tabs.map((tab) => {
+          const icon = tab.icon
+          // Lucide icons can be functions OR ForwardRef objects ({$$typeof, render})
+          const isComponent =
+            typeof icon === "function" ||
+            (typeof icon === "object" &&
+              icon !== null &&
+              "$$typeof" in icon &&
+              !React.isValidElement(icon))
+
+          const iconElement = isComponent
+            ? React.createElement(icon as React.ComponentType<{ className?: string; strokeWidth?: number }>, {
+                className: cn("h-4 w-4 shrink-0", tab.iconColor),
+                strokeWidth: 2,
+              })
+            : React.isValidElement(icon) || typeof icon === "string" || typeof icon === "number"
+              ? icon
+              : null
+
+          return (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              className={cn(pillTriggerBase, pillTriggerActive)}
+            >
+              {iconElement}
+              <span>{tab.label}</span>
+            </TabsTrigger>
+          )
+        })}
+      </TabsList>
+      {children}
+    </Tabs>
+  )
+}
+
+PlatformPillTabs.Content = TabsContent

--- a/components/ui/report-section.tsx
+++ b/components/ui/report-section.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface ReportSectionProps {
+  title: string
+  description: string
+  children: React.ReactNode
+  className?: string
+}
+
+export const ReportSection = ({
+  title,
+  description,
+  children,
+  className,
+}: ReportSectionProps) => {
+  return (
+    <section className={cn(className)}>
+      <h3 className="im-heading-4 text-foreground">{title}</h3>
+      <p className="mt-1 mb-4 im-text-body-sm im-text-muted">{description}</p>
+      {children}
+    </section>
+  )
+}

--- a/components/ui/stat-block.tsx
+++ b/components/ui/stat-block.tsx
@@ -10,6 +10,7 @@ interface StatBlockProps {
   labelClassName?: string
   valueClassName?: string
   icon?: ReactNode
+  iconPosition?: "top" | "bottom"
   variant?: "default" | "centered"
 }
 
@@ -20,19 +21,27 @@ export const StatBlock = ({
   labelClassName,
   valueClassName,
   icon,
+  iconPosition = "top",
   variant = "default",
 }: StatBlockProps) => {
   return (
     <div
       className={cn(
-        "rounded-lg bg-muted/10 p-3",
-        variant === "centered" && "text-center",
+        "rounded-lg bg-muted/10 p-3 flex flex-col",
+        variant === "centered" && "text-center items-center",
         className
       )}
     >
-      {icon && <div className="mb-2">{icon}</div>}
-      <div className={cn("text-sm text-muted-foreground", labelClassName)}>{label}</div>
-      <div className={cn("mt-1 text-lg font-semibold", valueClassName)}>{value}</div>
+      {icon && iconPosition === "top" && <div className="mb-2">{icon}</div>}
+      <div className={cn("text-sm text-muted-foreground", labelClassName)}>
+        {label}
+      </div>
+      <div className={cn("mt-1 text-lg font-semibold", valueClassName)}>
+        {value}
+      </div>
+      {icon && iconPosition === "bottom" && (
+        <div className="mt-2 text-muted-foreground">{icon}</div>
+      )}
     </div>
   )
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,119 @@ import { twMerge } from "tailwind-merge"
 export const cn = (...inputs: ClassValue[]) => {
   return twMerge(clsx(inputs))
 }
+
+/** Format ISO date string for display (e.g. "Feb 3, 2026") */
+export const formatDate = (iso: string): string => {
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })
+  } catch {
+    return iso
+  }
+}
+
+/** Format number with commas; return "—" if undefined */
+export const formatNumber = (n?: number): string => {
+  if (n === undefined || n === null) return "—"
+  return n.toLocaleString()
+}
+
+/** Format YYYY-MM date to "Jan '25" style for charts */
+export const formatChartMonth = (month: string): string => {
+  const m = month.match(/(\d{4})-(\d{2})/)
+  if (m) {
+    const [, year, mon] = m
+    const shortYear = year.length === 4 ? `'${year.slice(2)}` : year
+    const names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    return `${names[parseInt(mon, 10) - 1]} ${shortYear}`
+  }
+  return month
+}
+
+/** Format YYYY-MM date to short month name ("Jan") for charts */
+export const formatChartMonthShort = (month: string): string => {
+  const m = month.match(/(\d{4})-(\d{2})/)
+  if (m) {
+    const names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    return names[parseInt(m[2], 10) - 1]
+  }
+  return month
+}
+
+/** Truncate string with ellipsis */
+export const truncate = (s?: string, len = 20): string => {
+  if (!s) return "—"
+  if (s.length <= len) return s
+  return `${s.slice(0, len)}…`
+}
+
+/** Extract short display string from URL (domain or path) */
+export const prettyUrl = (url: string): string => {
+  try {
+    const u = new URL(url)
+    const host = u.hostname.replace(/^www\./, "")
+    if (host === "linktr.ee" && u.pathname.length > 1) {
+      return `linktr.ee${u.pathname}`
+    }
+    return host
+  } catch {
+    return url.length > 30 ? `${url.slice(0, 27)}…` : url
+  }
+}
+
+/** Known link aggregator hosts */
+const LINK_AGGREGATOR_HOSTS = [
+  "linktr.ee",
+  "bit.ly",
+  "tinyurl.com",
+  "short.link",
+  "bio.link",
+  "lnk.bio",
+]
+
+/** Check if URL points to a link aggregator (linktr.ee, bit.ly, etc.) */
+export const isLinkAggregator = (url: string): boolean => {
+  try {
+    const u = new URL(url)
+    const host = u.hostname.replace(/^www\./, "").toLowerCase()
+    return LINK_AGGREGATOR_HOSTS.some((h) => host === h || host.endsWith(`.${h}`))
+  } catch {
+    return false
+  }
+}
+
+/** Target market tokens (region/continent/country as marketing target) */
+const TARGET_MARKET_TOKENS = [
+  "europe",
+  "worldwide",
+  "uk",
+  "germany",
+  "usa",
+  "america",
+  "international",
+  "global",
+  "middle east",
+  "gulf",
+  "uae",
+  "dubai",
+]
+
+/** Classify geography token as location, target market, or fallback */
+export const classifyGeographyToken = (
+  token: string
+): "location" | "targetMarket" | "mentions" => {
+  const lower = token.trim().toLowerCase()
+  if (!lower) return "mentions"
+  if (TARGET_MARKET_TOKENS.includes(lower)) return "targetMarket"
+  return "location"
+}
+
+/** Check if any websiteCandidate is a direct clinic domain (not aggregator) */
+export const hasDirectDomain = (websiteCandidates?: string[]): boolean => {
+  if (!websiteCandidates?.length) return false
+  return websiteCandidates.some((url) => !isLinkAggregator(url))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.94.0",
         "class-variance-authority": "^0.7.1",
@@ -35,6 +36,7 @@
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "recharts": "^2.15.4",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.25.76"
@@ -4367,6 +4369,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
@@ -7912,6 +7944,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -8063,6 +8101,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dompurify": {
@@ -8976,6 +9024,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -11872,6 +11929,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -19956,6 +20019,21 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -19995,6 +20073,22 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -20019,6 +20113,44 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
@@ -22888,6 +23020,12 @@
         "real-require": "^0.2.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -23811,6 +23949,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.94.0",
     "class-variance-authority": "^0.7.1",
@@ -36,6 +37,7 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^2.15.4",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary

- Extract InstagramIntelligenceSection into focused subcomponents (profile/instagram/)
- Add reusable UI molecules: ComparisonMetricBlock, LineChartCard, BarChartCard
- Add chart utils (formatChartMonth, formatChartMonthShort) to lib/utils
- Fix platform-pill-tabs LucideIcon ForwardRef rendering (runtime error)
- Fix CommunitySignalsSection TabsContent component
- Add code quality Cursor rule (.cursor/rules/code-quality.mdc)
- Update components/ui/README.md taxonomy

Made with [Cursor](https://cursor.com)