### PR TITLE
Feature/website scraping

### DIFF
--- a/components/istanbulmedic-connect/ClinicCard.tsx
+++ b/components/istanbulmedic-connect/ClinicCard.tsx
@@ -26,7 +26,7 @@ interface ClinicCardProps {
   image: string | null
   specialties: string[]
   trustScore: number
-  description: string
+  description: string | null
   rating?: number
   reviewCount?: number
   aiInsight?: string

--- a/components/istanbulmedic-connect/ExploreClinicsPage.tsx
+++ b/components/istanbulmedic-connect/ExploreClinicsPage.tsx
@@ -29,7 +29,7 @@ interface ExploreClinicsPageProps {
 }
 
 const ENABLED_SORT_OPTIONS = (Object.keys(SORT_CONFIG) as ClinicSortOption[])
-  .filter((sortOption) => SORT_CONFIG[sortOption])
+  .filter((sortOption) => (SORT_CONFIG as Record<string, boolean>)[sortOption])
 
 const DEFAULT_SORT_OPTION: ClinicSortOption = ENABLED_SORT_OPTIONS[0] ?? "Alphabetical"
 

--- a/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
+++ b/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
@@ -257,13 +257,14 @@ export const ClinicProfilePage = ({ clinic }: ClinicProfilePageProps) => {
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           {/* Main Content Column */}
           <div className="space-y-6 lg:col-span-2">
-            {FEATURE_CONFIG.profileOverview && (
+            {FEATURE_CONFIG.profileOverview && (clinic.description || (clinic.techniques ?? []).length > 0) && (
               <OverviewSection
                 specialties={specialties}
                 yearsInOperation={yearsInOperation}
                 proceduresPerformed={proceduresPerformed}
                 languages={languages}
                 description={clinic.description}
+                techniques={clinic.techniques ?? []}
               />
             )}
 

--- a/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
+++ b/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
@@ -263,7 +263,7 @@ export const ClinicProfilePage = ({ clinic }: ClinicProfilePageProps) => {
                 yearsInOperation={yearsInOperation}
                 proceduresPerformed={proceduresPerformed}
                 languages={languages}
-                description={clinic.description}
+                description={clinic.description ?? ''}
                 techniques={clinic.techniques ?? []}
               />
             )}

--- a/components/istanbulmedic-connect/profile/OverviewSection.tsx
+++ b/components/istanbulmedic-connect/profile/OverviewSection.tsx
@@ -11,6 +11,7 @@ interface OverviewSectionProps {
   proceduresPerformed: number | null
   languages: string[]
   description: string
+  techniques: string[]
 }
 
 export const OverviewSection = ({
@@ -19,6 +20,7 @@ export const OverviewSection = ({
   proceduresPerformed,
   languages,
   description,
+  techniques,
 }: OverviewSectionProps) => {
   return (
     <Card id="overview" variant="profile" className="scroll-mt-32">
@@ -36,13 +38,10 @@ export const OverviewSection = ({
 
         <Separator />
 
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <StatBlock label="Years in operation" value={yearsInOperation ?? "Not available"} />
-          <StatBlock
-            label="Procedures performed"
-            value={proceduresPerformed !== null ? proceduresPerformed.toLocaleString() : "Not available"}
-          />
-          <StatBlock label="Languages" value={languages.length > 0 ? languages.length : "Not available"} />
+        <div className="flex flex-wrap gap-4">
+          {techniques.length > 0 && (
+            <StatBlock label="Techniques" value={techniques.join(", ")} />
+          )}
         </div>
 
         <div className="text-base leading-relaxed text-muted-foreground">{description}</div>

--- a/components/istanbulmedic-connect/profile/OverviewSection.tsx
+++ b/components/istanbulmedic-connect/profile/OverviewSection.tsx
@@ -10,7 +10,7 @@ interface OverviewSectionProps {
   yearsInOperation: number | null
   proceduresPerformed: number | null
   languages: string[]
-  description: string
+  description: string | null
   techniques: string[]
 }
 

--- a/components/istanbulmedic-connect/types.ts
+++ b/components/istanbulmedic-connect/types.ts
@@ -8,7 +8,7 @@ export interface Clinic {
   accreditations: string[]
   trustScore: number
   trustBand?: 'A' | 'B' | 'C' | 'D' | null
-  description: string
+  description: string | null
   rating?: number
   reviewCount?: number
   aiInsight?: string

--- a/lib/api/clinics.ts
+++ b/lib/api/clinics.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import type { Tables } from '@/lib/supabase/database.types';
-import type { InstagramSignalsData } from '@/components/istanbulmedic-connect/profile/InstagramSignalsCard';
-import { getInstagramSignals } from './instagram';
+import type { InstagramSignalsData } from '@/components/istanbulmedic-connect/profile/InstagramIntelligenceSection';
+import { getClinicInstagramData } from './instagram';
 
 // Database row types
 type ClinicRow = Tables<'clinics'>;
@@ -662,11 +662,11 @@ export async function getClinicById(clinicId: string): Promise<ClinicDetail | nu
   const imageUrl = imageMedia[0]?.url ?? null;
 
   // Fetch Instagram signals data (returns null if no Instagram profile exists)
-  const instagramSignals = await getInstagramSignals(clinic.id);
+  const instagramSignals = await getClinicInstagramData(clinic.id);
   
   const scrapedData = Array.isArray(clinic.clinic_scraped_data)
     ? clinic.clinic_scraped_data[0]
-    : (clinic.clinic_scraped_data as { description: string | null } | null);
+    : (clinic.clinic_scraped_data as unknown as { description: string | null } | null);
 
   return {
     id: clinic.id,

--- a/lib/api/clinics.ts
+++ b/lib/api/clinics.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import type { Tables } from '@/lib/supabase/database.types';
-import type { InstagramIntelligenceVM } from '@/components/istanbulmedic-connect/types';
-import { getClinicInstagramData } from './instagram';
+import type { InstagramSignalsData } from '@/components/istanbulmedic-connect/profile/InstagramSignalsCard';
+import { getInstagramSignals } from './instagram';
 
 // Database row types
 type ClinicRow = Tables<'clinics'>;
@@ -25,6 +25,7 @@ export type ClinicSortOption =
   | 'Alphabetical'
   | 'Best Match'
   | 'Highest Rated'
+  | 'Lowest Rated'
   | 'Most Transparent'
   | 'Price: Low to High'
   | 'Price: High to Low';
@@ -61,7 +62,7 @@ export interface ClinicListItem {
   accreditations: string[];
   trustScore: number;
   trustBand: 'A' | 'B' | 'C' | 'D' | null;
-  description: string;
+  description: string | null;
   rating?: number;
   reviewCount?: number;
   aiInsight?: string;
@@ -91,8 +92,9 @@ export interface ClinicDetail extends Omit<ClinicListItem, 'languages'> {
   proceduresPerformed: number | null;
   /** Total review count from clinic_facts (actual Google total, not scraped count) */
   totalReviewCount: number;
-  /** Instagram profile and posts data (null if no Instagram data exists) */
-  instagram: InstagramIntelligenceVM | null;
+  /** Instagram signals data for trust indicators (null if no Instagram data exists) */
+  instagramSignals: InstagramSignalsData | null;
+  techniques: string[] | null;
 }
 
 const normalizeString = (value?: string | null) => value?.trim().toLowerCase() ?? '';
@@ -112,6 +114,7 @@ type ClinicCredentialPartial = Pick<ClinicCredentialRow, 'credential_type' | 'cr
 type ClinicMediaPartial = Pick<ClinicMediaRow, 'url' | 'is_primary' | 'display_order' | 'media_type'>;
 type ClinicFactPartial = Pick<ClinicFactRow, 'fact_key' | 'fact_value'>;
 type ClinicGooglePlacesPartial = Pick<ClinicGooglePlacesRow, 'rating' | 'user_ratings_total'>;
+type ClinicScrapedDataPartial = { description: string | null };
 
 type ClinicListQueryRow = {
   id: string;
@@ -125,6 +128,7 @@ type ClinicListQueryRow = {
   clinic_media?: ClinicMediaPartial[] | null;
   clinic_facts?: ClinicFactPartial[] | null;
   clinic_google_places?: ClinicGooglePlacesPartial[] | ClinicGooglePlacesPartial | null;
+  clinic_scraped_data?: ClinicScrapedDataPartial[] | ClinicScrapedDataPartial | null;
 };
 
 const mapClinicRow = (clinic: ClinicListQueryRow): ClinicListItem => {
@@ -183,6 +187,10 @@ const mapClinicRow = (clinic: ClinicListQueryRow): ClinicListItem => {
     ? clinic.clinic_google_places[0]
     : clinic.clinic_google_places;
 
+  const scrapedData = Array.isArray(clinic.clinic_scraped_data)
+    ? clinic.clinic_scraped_data[0]
+    : clinic.clinic_scraped_data;
+
   return {
     id: clinic.id,
     name: clinic.display_name,
@@ -193,7 +201,7 @@ const mapClinicRow = (clinic: ClinicListQueryRow): ClinicListItem => {
     accreditations,
     trustScore: score?.overall_score ?? 0,
     trustBand: score?.band ?? null,
-    description: `Quality healthcare clinic in ${clinic.primary_city}.`,
+    description: scrapedData?.description ?? null,
     rating: googlePlaces?.rating ?? undefined,
     reviewCount: googlePlaces?.user_ratings_total ?? undefined,
     aiInsight: undefined,
@@ -209,7 +217,8 @@ export async function getClinics(query: ClinicsQuery = {}): Promise<ClinicsResul
   const pageSize = Math.max(1, Math.min(query.pageSize ?? 12, 50));
   const page = Math.max(1, query.page ?? 1);
   const sort = query.sort ?? 'Best Match';
-  const isHighestRatedSort = sort === 'Highest Rated';
+  // These sorts require the view for proper ORDER BY
+  const needsViewSort = sort === 'Highest Rated' || sort === 'Lowest Rated' || sort === 'Best Match' || sort === 'Most Transparent';
 
   const searchQuery = normalizeString(query.searchQuery);
   const locationQuery = normalizeString(query.location);
@@ -377,6 +386,70 @@ export async function getClinics(query: ClinicsQuery = {}): Promise<ClinicsResul
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;
 
+  // For sorts that need score/rating, use the view to get sorted IDs first
+  let sortedClinicIds: string[] | null = null;
+  let totalCount = 0;
+
+  if (needsViewSort) {
+    // Query the view for sorted, paginated clinic IDs
+    // Note: Regenerate Supabase types after applying the view migration
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let viewQuery = (supabase.from as any)('clinics_with_scores')
+      .select('id', { count: 'exact' })
+      .eq('status', 'active');
+
+    if (filteredIds) {
+      viewQuery = viewQuery.in('id', Array.from(filteredIds));
+    }
+
+    if (locationQuery) {
+      viewQuery = viewQuery.or(
+        `primary_city.ilike.%${locationQuery}%,primary_country.ilike.%${locationQuery}%`
+      );
+    }
+
+    // Apply sort on the view (direct column access, no referencedTable needed)
+    switch (sort) {
+      case 'Highest Rated':
+        viewQuery = viewQuery
+          .order('google_rating', { ascending: false, nullsFirst: false })
+          .order('google_review_count', { ascending: false, nullsFirst: false })
+          .order('display_name', { ascending: true });
+        break;
+      case 'Lowest Rated':
+        viewQuery = viewQuery
+          .order('google_rating', { ascending: true, nullsFirst: false })
+          .order('google_review_count', { ascending: true, nullsFirst: false })
+          .order('display_name', { ascending: true });
+        break;
+      case 'Best Match':
+      case 'Most Transparent':
+        viewQuery = viewQuery
+          .order('overall_score', { ascending: false, nullsFirst: false })
+          .order('display_name', { ascending: true });
+        break;
+    }
+
+    const { data: sortedRows, error: viewError, count: viewCount } = await viewQuery.range(from, to) as {
+      data: { id: string }[] | null;
+      error: Error | null;
+      count: number | null;
+    };
+
+    if (viewError) {
+      console.error('Error fetching sorted clinic IDs:', viewError);
+      throw new Error(`Failed to fetch clinics: ${viewError.message}`);
+    }
+
+    if (!sortedRows || sortedRows.length === 0) {
+      return { clinics: [], total: viewCount ?? 0, page, pageSize };
+    }
+
+    sortedClinicIds = sortedRows.map((row) => row.id);
+    totalCount = viewCount ?? 0;
+  }
+
+  // Build main query for full clinic data with relations
   let queryBuilder = supabase
     .from('clinics')
     .select(
@@ -410,49 +483,50 @@ export async function getClinics(query: ClinicsQuery = {}): Promise<ClinicsResul
       clinic_google_places (
         rating,
         user_ratings_total
+      ),
+      clinic_scraped_data (
+        description
       )
     `,
-      { count: 'exact' }
+      { count: needsViewSort ? undefined : 'exact' }
     )
     .eq('status', 'active');
 
-  if (filteredIds) {
-    queryBuilder = queryBuilder.in('id', Array.from(filteredIds));
+  if (needsViewSort && sortedClinicIds) {
+    // Use the pre-sorted IDs from the view query
+    queryBuilder = queryBuilder.in('id', sortedClinicIds);
+  } else {
+    // Apply filters directly for non-view sorts
+    if (filteredIds) {
+      queryBuilder = queryBuilder.in('id', Array.from(filteredIds));
+    }
+
+    if (locationQuery) {
+      queryBuilder = queryBuilder.or(
+        `primary_city.ilike.%${locationQuery}%,primary_country.ilike.%${locationQuery}%`
+      );
+    }
   }
 
-  if (locationQuery) {
-    queryBuilder = queryBuilder.or(
-      `primary_city.ilike.%${locationQuery}%,primary_country.ilike.%${locationQuery}%`
-    );
+  // Apply sort for non-view sorts
+  if (!needsViewSort) {
+    switch (sort) {
+      case 'Alphabetical':
+        queryBuilder = queryBuilder.order('display_name', { ascending: true });
+        break;
+      case 'Price: Low to High':
+        queryBuilder = queryBuilder.order('display_name', { ascending: true });
+        break;
+      case 'Price: High to Low':
+        queryBuilder = queryBuilder.order('display_name', { ascending: false });
+        break;
+      default:
+        queryBuilder = queryBuilder.order('display_name', { ascending: true });
+        break;
+    }
   }
 
-  switch (sort) {
-    case 'Alphabetical':
-      queryBuilder = queryBuilder.order('display_name', { ascending: true });
-      break;
-    case 'Highest Rated':
-      // Highest Rated is sorted at the clinic level after fetch to avoid
-      // relation-order semantics that do not reliably reorder parent rows.
-      queryBuilder = queryBuilder.order('display_name', { ascending: true });
-      break;
-    case 'Most Transparent':
-    case 'Best Match':
-      queryBuilder = queryBuilder.order('overall_score', {
-        referencedTable: 'clinic_scores',
-        ascending: false,
-      });
-      break;
-    case 'Price: Low to High':
-      queryBuilder = queryBuilder.order('display_name', { ascending: true });
-      break;
-    case 'Price: High to Low':
-      queryBuilder = queryBuilder.order('display_name', { ascending: false });
-      break;
-    default:
-      break;
-  }
-
-  const { data: clinics, error, count } = isHighestRatedSort
+  const { data: clinics, error, count } = needsViewSort
     ? await queryBuilder
     : await queryBuilder.range(from, to);
 
@@ -463,35 +537,21 @@ export async function getClinics(query: ClinicsQuery = {}): Promise<ClinicsResul
 
   if (!clinics) return { clinics: [], total: 0, page, pageSize };
 
-  const mappedClinics = clinics.map(mapClinicRow);
+  let mappedClinics = clinics.map(mapClinicRow);
 
-  if (isHighestRatedSort) {
-    const sortedClinics = [...mappedClinics].sort((a, b) => {
-      const aRating = a.rating ?? -1;
-      const bRating = b.rating ?? -1;
-      if (bRating !== aRating) return bRating - aRating;
-
-      const aReviews = a.reviewCount ?? -1;
-      const bReviews = b.reviewCount ?? -1;
-      if (bReviews !== aReviews) return bReviews - aReviews;
-
-      const byName = a.name.localeCompare(b.name);
-      if (byName !== 0) return byName;
-
-      return a.id.localeCompare(b.id);
+  // For view-based sorts, preserve the order from sortedClinicIds
+  if (needsViewSort && sortedClinicIds) {
+    const idOrder = new Map(sortedClinicIds.map((id, index) => [id, index]));
+    mappedClinics = mappedClinics.sort((a, b) => {
+      const aIndex = idOrder.get(a.id) ?? 999;
+      const bIndex = idOrder.get(b.id) ?? 999;
+      return aIndex - bIndex;
     });
-
-    return {
-      clinics: sortedClinics.slice(from, to + 1),
-      total: count ?? sortedClinics.length,
-      page,
-      pageSize,
-    };
   }
 
   return {
     clinics: mappedClinics,
-    total: count ?? 0,
+    total: needsViewSort ? totalCount : (count ?? 0),
     page,
     pageSize,
   };
@@ -520,7 +580,8 @@ export async function getClinicById(clinicId: string): Promise<ClinicDetail | nu
       clinic_pricing (*),
       clinic_team (*),
       clinic_packages (*),
-      clinic_reviews (*, sources (source_name, source_type))
+      clinic_reviews (*, sources (source_name, source_type)),
+      clinic_scraped_data (*)
     `)
     .eq('id', clinicId)
     .single();
@@ -600,8 +661,12 @@ export async function getClinicById(clinicId: string): Promise<ClinicDetail | nu
     });
   const imageUrl = imageMedia[0]?.url ?? null;
 
-  // Fetch Instagram data (returns null if no Instagram profile exists)
-  const instagram = await getClinicInstagramData(clinic.id);
+  // Fetch Instagram signals data (returns null if no Instagram profile exists)
+  const instagramSignals = await getInstagramSignals(clinic.id);
+  
+  const scrapedData = Array.isArray(clinic.clinic_scraped_data)
+    ? clinic.clinic_scraped_data[0]
+    : (clinic.clinic_scraped_data as { description: string | null } | null);
 
   return {
     id: clinic.id,
@@ -612,7 +677,7 @@ export async function getClinicById(clinicId: string): Promise<ClinicDetail | nu
     specialties: specialties.length > 0 ? specialties : ['Medical Tourism'],
     trustScore: score?.overall_score ?? 0,
     trustBand: score?.band ?? null,
-    description: `${clinic.display_name} - Quality healthcare in ${clinic.primary_city}.`,
+    description: scrapedData?.description ?? null,
     rating: googlePlaces?.rating ?? undefined,
     reviewCount: googlePlaces?.user_ratings_total ?? undefined,
     aiInsight: undefined,
@@ -638,7 +703,8 @@ export async function getClinicById(clinicId: string): Promise<ClinicDetail | nu
     yearsInOperation: clinic.years_in_operation,
     proceduresPerformed: clinic.procedures_performed,
     totalReviewCount: googlePlaces?.user_ratings_total ?? 0,
-    instagram,
+    instagramSignals,
+    techniques: scrapedData?.techniques ?? null,
   };
 }
 

--- a/lib/filterConfig.ts
+++ b/lib/filterConfig.ts
@@ -72,7 +72,7 @@ export const FEATURE_CONFIG = {
   personalizedOffers: false, // landing page "Receive Personalized Offers" step
 
   // Profile sections - disabled until real data
-  profileOverview: false,
+  profileOverview: true,
   profilePricing: false,
   profilePackages: false,
   profileDoctors: false,

--- a/scripts/clinic-website-scraper.py
+++ b/scripts/clinic-website-scraper.py
@@ -1,0 +1,651 @@
+"""
+Hair Transplant Clinic Data Pipeline — Focused Edition
+=======================================================
+STEP 1 OF 2 in the clinic data pipeline.
+
+What this does:
+  Scrapes clinic websites and extracts structured data using a local LLM (Ollama/llama3).
+  Extracts: techniques, services, pricing, doctors, certifications, descriptions, trust signals.
+  Phone/email/social/reviews are intentionally omitted (sourced from Google separately).
+
+Output:
+  output/clinics.json  — structured data ready for push-clinics.py
+  output/clinics.csv   — flat version for inspection
+
+Usage:
+  1. Make sure Ollama is running locally with llama3: ollama run llama3
+  2. Edit TARGET_URLS at the top of this file to add/remove clinics
+  3. Run: python clinic-website-scraper2.py
+  4. Then push to Supabase: python push-clinics.py output/clinics.json
+
+Requirements:
+    pip install requests beautifulsoup4 pandas tqdm ollama
+"""
+import json
+import time
+import random
+import logging
+import re
+import sys
+import ollama
+from dataclasses import dataclass, field, asdict
+from urllib.parse import urljoin, urlparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+sys.stdout.reconfigure(encoding='utf-8')
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+TARGET_URLS = [
+    "https://www.dentalhairclinicturkey.com/",
+    "https://lenusclinic.com/",
+    "https://drterziler.com/",
+    "https://www.aekhairclinic.com/",
+    "https://www.memorial.com.tr/en/hair-transplant-turkey",
+    "https://www.estemedicalgroup.com/",
+    "https://www.estenove.com/",
+    "https://hermestclinic.com/",
+    "https://www.dokuclinic.com/en",
+    "https://asthetica.com/",
+    "https://www.longevita.co.uk/",
+    "https://hairtransplantist.com/",
+    "https://www.drserkanaygin.com/",
+    "https://www.veraclinic.net/",
+    "https://www.cosmedica.com/",
+    "https://www.smilehairclinic.com/",
+    "https://www.hlcclinic.com/",
+    "https://www.asmed.com/",
+    "https://www.drpekiner.com/",
+    "https://www.hermesthairclinic.com/",
+    "https://www.drcinik.com/",
+    "https://www.ahdclinic.com/",
+    "https://www.clinicana.com/",
+    "https://www.resul-yaman.com/",
+    "https://www.estetikInternational.com/",
+    "https://www.sapphirehairclinic.com/",
+    "https://www.medicalhair.clinic/",
+    "https://www.drthairclinic.com/",
+    "https://www.estefavor.com/",
+    "https://www.sulehairtransplant.com/",
+]
+
+OUTPUT_DIR      = Path("output")
+DELAY_RANGE     = (1.5, 3.5)
+TIMEOUT         = 20
+OLLAMA_MODEL    = "llama3"
+MAX_CHARS       = 4000
+MAX_TOTAL_CHARS = 6000
+MAX_SUBPAGES    = 6
+
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        logging.FileHandler("pipeline.log", encoding="utf-8"),
+    ],
+)
+log = logging.getLogger(__name__)
+
+# ── Data Model ────────────────────────────────────────────────────────────────
+
+@dataclass
+class ClinicData:
+    # Identity
+    url: str = ""
+    name: str = ""
+    slug: str = ""
+
+    # Location
+    address: str = ""
+    city: str = ""
+    country: str = ""
+
+    # Google placeholder (merge later)
+    google_place_id: str = ""
+
+    # Short description
+    description: str = ""
+
+    # Techniques & services
+    techniques: list = field(default_factory=list)
+    services: list = field(default_factory=list)
+    body_areas: list = field(default_factory=list)
+    languages_spoken: list = field(default_factory=list)
+
+    # Pricing
+    price_range_raw: str = ""
+    price_per_graft_usd: float | None = None
+    price_min_usd: float | None = None
+    price_max_usd: float | None = None
+    currency_noted: str = ""
+    financing_available: bool = False
+
+    # Medical team
+    doctors: list = field(default_factory=list)
+    certifications: list = field(default_factory=list)
+    memberships: list = field(default_factory=list)
+    accreditations: list = field(default_factory=list)
+
+    # Trust signals
+    years_experience: int | None = None
+    years_established: int | None = None
+    cases_performed: int | None = None
+    success_rate_pct: float | None = None
+
+    # Booking
+    has_online_booking: bool = False
+    offers_free_consultation: bool = False
+    offers_virtual_consultation: bool = False
+    booking_url: str = ""
+
+    # Content flags
+    has_before_after: bool = False
+
+    # Pipeline meta
+    scraped_at: str = ""
+    pages_scraped: int = 0
+    scrape_ok: bool = False
+    error: str = ""
+
+# ── Subpage Scoring ───────────────────────────────────────────────────────────
+
+SUBPAGE_SCORES = {
+    "pricing": 15, "cost": 15, "price": 15, "package": 14, "packages": 14,
+    "fee": 12, "fees": 12, "tariff": 12, "rates": 11, "quote": 10,
+    "doctor": 8, "surgeon": 8, "team": 8, "staff": 7, "specialist": 7,
+    "fue": 7, "fut": 7, "dhi": 7, "technique": 6, "method": 6, "procedure": 6,
+    "before": 6, "after": 6, "result": 6, "gallery": 5,
+    "about": 5, "accreditation": 4, "certification": 4, "award": 4,
+    "consultation": 4, "appointment": 4, "booking": 4,
+    "service": 4, "treatment": 4, "hair-transplant": 6,
+}
+
+SKIP_EXTENSIONS = (
+    ".pdf", ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg",
+    ".zip", ".mp4", ".mp3", ".webm", ".ico", ".woff", ".woff2"
+)
+
+# ── LLM Batches ───────────────────────────────────────────────────────────────
+
+SYSTEM_PROMPT = """You are a JSON data extraction API. You only output valid JSON. No explanations, no markdown, no code blocks. Only a flat JSON object with exactly the keys given."""
+
+BATCH_PROMPTS = [
+    ("basic", """From the website content below, extract ONLY these fields and return a flat JSON object:
+{
+  "name": "clinic name",
+  "address": "street address",
+  "city": "city name",
+  "country": "country name",
+  "has_online_booking": true or false,
+  "offers_free_consultation": true or false,
+  "offers_virtual_consultation": true or false,
+  "booking_url": "URL to booking page or empty string"
+}"""),
+    ("techniques", """From the website content below, extract ONLY these fields and return a flat JSON object:
+{
+  "techniques": ["array of technique names e.g. FUE, DHI, FUT, Sapphire FUE"],
+  "services": ["array of services e.g. beard transplant, eyebrow transplant, PRP"],
+  "body_areas": ["array of body areas treated e.g. scalp, beard, eyebrow"],
+  "languages_spoken": ["array of languages the clinic serves patients in"],
+  "has_before_after": true or false
+}"""),
+    ("pricing", """From the website content below, extract pricing information and return a flat JSON object.
+
+SEARCH FOR: any mention of cost, price, fee, package, graft, £, $, €, GBP, USD, EUR, TRY, lira.
+Examples of what to look for:
+  - "from £1,999" → price_min_usd (convert to USD: £1 ≈ $1.27)
+  - "€2 per graft" → price_per_graft_usd (convert: €1 ≈ $1.09)
+  - "packages from $1500 to $4000" → price_min_usd=1500, price_max_usd=4000
+  - "2500 grafts for £2500" → compute per-graft cost
+  - Prices in Turkish Lira (TRY): £1 ≈ 40 TRY, so divide by 40 then multiply by 1.27
+
+RULES:
+- price_range_raw: copy the EXACT pricing sentence(s) from the page verbatim. If none found, null.
+- price_per_graft_usd: price per graft converted to USD as a number, or null
+- price_min_usd: minimum package price in USD as a number, or null
+- price_max_usd: maximum package price in USD as a number, or null
+- currency_noted: the original currency symbol or code seen (e.g. "GBP", "EUR", "USD", "TRY")
+- financing_available: true if installments, finance, payment plan mentioned
+
+{
+  "price_range_raw": null,
+  "price_per_graft_usd": null,
+  "price_min_usd": null,
+  "price_max_usd": null,
+  "currency_noted": null,
+  "financing_available": false
+}"""),
+    ("description", """From the website content below, write a SHORT factual description of this hair transplant clinic.
+
+Write 2-3 sentences (max 80 words) covering: location, main specialties/techniques, and any standout differentiators (e.g. lead surgeon's credentials, years of experience, package inclusions like hotel/transport, notable certifications).
+
+Be factual and neutral. Do not invent anything not stated on the page.
+
+Return ONLY this JSON object:
+{
+  "description": "2-3 sentence clinic summary here"
+}"""),
+    ("team", """From the website content below, extract ONLY these fields and return a flat JSON object.
+IMPORTANT: For doctors, only include real human names that start with Dr., Prof., or a first+last name. Do NOT include clinic names, slogans, or page titles.
+{
+  "doctors": [],
+  "certifications": [],
+  "memberships": [],
+  "accreditations": [],
+  "years_experience": null,
+  "years_established": null,
+  "cases_performed": null,
+  "success_rate_pct": null
+}"""),
+]
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def make_session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update({
+        "User-Agent": USER_AGENT,
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "Cache-Control": "max-age=0",
+    })
+    return s
+
+
+def get_soup(url: str, session: requests.Session) -> BeautifulSoup | None:
+    try:
+        r = session.get(url, timeout=TIMEOUT)
+        r.raise_for_status()
+        r.encoding = r.apparent_encoding or "utf-8"
+        return BeautifulSoup(r.content, "html.parser")
+    except Exception as e:
+        log.warning(f"Fetch failed {url}: {e}")
+        return None
+
+
+def polite_delay():
+    time.sleep(random.uniform(*DELAY_RANGE))
+
+
+def clean_text(soup: BeautifulSoup) -> str:
+    for tag in soup(["script", "style", "noscript", "header", "footer",
+                     "nav", "aside", "form", "iframe"]):
+        tag.decompose()
+    text = soup.get_text(separator=" ", strip=True)
+    text = re.sub(r"\s+", " ", text)
+    return text[:MAX_CHARS]
+
+
+def find_subpages(soup: BeautifulSoup, base_url: str) -> list[str]:
+    base_netloc = urlparse(base_url).netloc
+    scored: dict[str, int] = {}
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        full = urljoin(base_url, href)
+        if urlparse(full).netloc != base_netloc:
+            continue
+        if any(full.lower().endswith(ext) for ext in SKIP_EXTENSIONS):
+            continue
+        if "wp-content" in full or "wp-json" in full:
+            continue
+        if full == base_url or full == base_url.rstrip("/"):
+            continue
+
+        path = urlparse(full).path.lower()
+        link_text = a.get_text().lower()
+        combined = path + " " + link_text
+
+        score = sum(pts for kw, pts in SUBPAGE_SCORES.items() if kw in combined)
+        if score > 0:
+            scored[full] = max(scored.get(full, 0), score)
+
+    ranked = sorted(scored.items(), key=lambda x: x[1], reverse=True)
+    log.info(f"  Found {len(ranked)} relevant subpages")
+    return [url for url, _ in ranked[:MAX_SUBPAGES]]
+
+# ── Price Pre-Extraction ──────────────────────────────────────────────────────
+
+# Matches things like: £1,999  $2.50/graft  €1500-€3000  2000 USD  from 1,500 GBP
+_PRICE_RE = re.compile(
+    r"""
+    (?:from\s*)?                        # optional "from"
+    ([\$£€₺]|\bUSD\b|\bGBP\b|\bEUR\b|\bTRY\b)  # currency symbol or code
+    \s*
+    ([\d,]+(?:\.\d{1,2})?)             # amount
+    (?:\s*[-–to]+\s*[\$£€₺]?\s*([\d,]+(?:\.\d{1,2})?))?   # optional range end
+    (?:\s*/\s*graft)?                   # optional "/graft"
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_CURRENCY_RATES_TO_USD = {
+    "$": 1.0, "USD": 1.0,
+    "£": 1.27, "GBP": 1.27,
+    "€": 1.09, "EUR": 1.09,
+    "₺": 0.031, "TRY": 0.031,
+}
+
+
+def _to_float(s: str) -> float | None:
+    try:
+        return float(s.replace(",", ""))
+    except Exception:
+        return None
+
+
+def regex_extract_prices(pages_text: list[str]) -> dict:
+    """Quick regex pass to pull price signals before the LLM runs."""
+    combined = " ".join(pages_text)
+    hits = _PRICE_RE.findall(combined)
+    if not hits:
+        return {}
+
+    amounts_usd = []
+    currency_seen = None
+    raw_snippets = []
+
+    for currency, amount_str, range_end_str in hits:
+        rate = _CURRENCY_RATES_TO_USD.get(currency.upper(), 1.0)
+        if not currency_seen:
+            currency_seen = currency.upper()
+        amt = _to_float(amount_str)
+        if amt:
+            amounts_usd.append(amt * rate)
+            snippet = f"{currency}{amount_str}"
+            if range_end_str:
+                end = _to_float(range_end_str)
+                if end:
+                    amounts_usd.append(end * rate)
+                    snippet += f"–{range_end_str}"
+            raw_snippets.append(snippet)
+
+    if not amounts_usd:
+        return {}
+
+    result: dict = {
+        "price_range_raw": ", ".join(raw_snippets[:6]),
+        "currency_noted": currency_seen,
+    }
+    if len(amounts_usd) == 1:
+        result["price_min_usd"] = round(amounts_usd[0], 2)
+    else:
+        result["price_min_usd"] = round(min(amounts_usd), 2)
+        result["price_max_usd"] = round(max(amounts_usd), 2)
+
+    # Heuristic: if all values < 10, they're likely per-graft prices
+    if all(v < 15 for v in amounts_usd):
+        result["price_per_graft_usd"] = round(sum(amounts_usd) / len(amounts_usd), 2)
+
+    log.info(f"  [regex-price] found: {result}")
+    return result
+
+
+
+
+# ── LLM Extraction ────────────────────────────────────────────────────────────
+    combined = "\n\n---PAGE BREAK---\n\n".join(pages_text)
+    content = combined[:MAX_TOTAL_CHARS]
+    merged = {}
+
+    for batch_name, schema_prompt in BATCH_PROMPTS:
+        prompt = f"""{schema_prompt}
+
+Return ONLY the JSON object, nothing else. No explanation. No markdown.
+
+Website: {url}
+
+Content:
+{content}
+
+JSON output:"""
+
+        try:
+            response = ollama.chat(
+                model=OLLAMA_MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user",   "content": prompt},
+                ],
+                options={"temperature": 0, "num_predict": 800, "num_ctx": 8192},
+            )
+            raw = response["message"]["content"].strip()
+            log.info(f"  [{batch_name}] preview: {raw[:100]}")
+
+            raw = re.sub(r"^```(?:json)?\s*", "", raw)
+            raw = re.sub(r"\s*```$", "", raw.strip())
+
+            match = re.search(r"\{[^{}]*\}", raw, re.DOTALL)
+            if match:
+                parsed = json.loads(match.group(0))
+                merged.update({k: v for k, v in parsed.items()
+                                if v not in [None, "", [], {}]})
+            else:
+                log.warning(f"  [{batch_name}] No JSON object found")
+
+        except json.JSONDecodeError as e:
+            log.warning(f"  [{batch_name}] Invalid JSON: {e}")
+        except Exception as e:
+            log.warning(f"  [{batch_name}] LLM call failed: {e}")
+
+    return merged
+
+# ── Core Scraper ──────────────────────────────────────────────────────────────
+
+def extract_name_from_html(soup: BeautifulSoup) -> str:
+    """Extract clinic name from HTML meta tags before the LLM runs."""
+    # og:site_name is the most reliable — set intentionally by the site owner
+    og = soup.find("meta", property="og:site_name")
+    if og and og.get("content", "").strip():
+        return og["content"].strip()
+
+    # <title> tag — split on common separators and take the first part
+    title = soup.find("title")
+    if title and title.text.strip():
+        name = re.split(r"[|\-–—]", title.text)[0].strip()
+        # Reject if it looks like a page title rather than a clinic name
+        if name and not any(kw in name.lower() for kw in [
+            "hair transplant", "home", "welcome", "page", "index"
+        ]):
+            return name
+
+    # h1 as last resort
+    h1 = soup.find("h1")
+    if h1 and h1.text.strip():
+        return h1.text.strip()[:80]
+
+    return ""
+
+
+def merge_llm_result(data: ClinicData, result: dict):
+    for key, val in result.items():
+        if not hasattr(data, key) or val is None or val == "" or val == []:
+            continue
+        existing = getattr(data, key)
+        # Never overwrite the name if we already got it from HTML
+        if key == "name" and data.name:
+            continue
+        if existing in [None, "", [], False, 0]:
+            try:
+                setattr(data, key, val)
+            except Exception:
+                pass
+    if data.name and not data.slug:
+        data.slug = slugify(data.name)
+
+def extract_with_llm(pages_text: list[str], url: str) -> dict:
+    combined = "\n\n---PAGE BREAK---\n\n".join(pages_text)
+    content = combined[:MAX_TOTAL_CHARS]
+    merged = {}
+
+    for batch_name, schema_prompt in BATCH_PROMPTS:
+        prompt = f"""{schema_prompt}
+
+Return ONLY the JSON object, nothing else. No explanation. No markdown.
+
+Website: {url}
+
+Content:
+{content}
+
+JSON output:"""
+
+        try:
+            response = ollama.chat(
+                model=OLLAMA_MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user",   "content": prompt},
+                ],
+                options={"temperature": 0, "num_predict": 800, "num_ctx": 8192},
+            )
+            raw = response["message"]["content"].strip()
+            log.info(f"  [{batch_name}] preview: {raw[:100]}")
+
+            raw = re.sub(r"^```(?:json)?\s*", "", raw)
+            raw = re.sub(r"\s*```$", "", raw.strip())
+
+            match = re.search(r"\{[^{}]*\}", raw, re.DOTALL)
+            if match:
+                parsed = json.loads(match.group(0))
+                merged.update({k: v for k, v in parsed.items()
+                                if v not in [None, "", [], {}]})
+            else:
+                log.warning(f"  [{batch_name}] No JSON object found")
+
+        except json.JSONDecodeError as e:
+            log.warning(f"  [{batch_name}] Invalid JSON: {e}")
+        except Exception as e:
+            log.warning(f"  [{batch_name}] LLM call failed: {e}")
+
+    return merged
+
+def scrape_clinic(url: str, session: requests.Session) -> ClinicData:
+    data = ClinicData(url=url, scraped_at=datetime.now(timezone.utc).isoformat())
+    log.info(f"Scraping: {url}")
+
+    soup = get_soup(url, session)
+    if not soup:
+        data.error = "Failed to fetch homepage"
+        return data
+
+    pages_text = [clean_text(soup)]
+    data.pages_scraped = 1
+
+    # Extract name from HTML before LLM so it can't be overwritten
+    data.name = extract_name_from_html(soup)
+    if data.name:
+        data.slug = slugify(data.name)
+        log.info(f"  Name from HTML: {data.name}")
+
+    for sp_url in find_subpages(soup, url):
+        polite_delay()
+        sp_soup = get_soup(sp_url, session)
+        if sp_soup:
+            pages_text.append(clean_text(sp_soup))
+            data.pages_scraped += 1
+            log.info(f"  + {sp_url}")
+
+    total_chars = sum(len(p) for p in pages_text)
+    log.info(f"  {data.pages_scraped} pages ({total_chars} chars) — sending to LLM...")
+    log.info(f"  Content preview: {pages_text[0][:200]}")
+
+    # Trim total
+    trimmed, total = [], 0
+    for p in pages_text:
+        if total + len(p) > MAX_TOTAL_CHARS:
+            rem = MAX_TOTAL_CHARS - total
+            if rem > 500:
+                trimmed.append(p[:rem])
+            break
+        trimmed.append(p)
+        total += len(p)
+
+    result = extract_with_llm(trimmed, url)
+
+    # Seed with regex-extracted prices; LLM can refine but not erase regex hits
+    regex_prices = regex_extract_prices(trimmed)
+    for k, v in regex_prices.items():
+        if k not in result or result[k] in [None, "", [], {}]:
+            result[k] = v
+    if result:
+        merge_llm_result(data, result)
+        data.scrape_ok = True
+        log.info(f"  Done: {data.name or url} | {data.city or '?'} | graft=${data.price_per_graft_usd}")
+    else:
+        data.error = "LLM extraction failed"
+
+    return data
+
+# ── Pipeline & Output ─────────────────────────────────────────────────────────
+
+def run_pipeline(urls: list[str]) -> list[ClinicData]:
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    session = make_session()
+    results: list[ClinicData] = []
+    for url in tqdm(urls, desc="Scraping clinics"):
+        results.append(scrape_clinic(url, session))
+        polite_delay()
+    return results
+
+
+def save_results(results: list[ClinicData]):
+    records = [asdict(r) for r in results]
+
+    json_path = OUTPUT_DIR / "clinics.json"
+    json_path.write_text(json.dumps(records, indent=2, ensure_ascii=False), encoding="utf-8")
+    log.info(f"Saved -> {json_path}")
+
+    flat = []
+    for r in records:
+        row = {}
+        for k, v in r.items():
+            if isinstance(v, list):
+                row[k] = " | ".join(str(x) for x in v)
+            else:
+                row[k] = v
+        flat.append(row)
+
+    csv_path = OUTPUT_DIR / "clinics.csv"
+    pd.DataFrame(flat).to_csv(csv_path, index=False, encoding="utf-8")
+    log.info(f"Saved -> {csv_path}")
+
+    ok = [r for r in results if r.scrape_ok]
+    print(f"\n-- Summary --")
+    print(f"  Scraped      : {len(results)}  ok={len(ok)}  failed={len(results)-len(ok)}")
+    if ok:
+        prices = [r.price_per_graft_usd for r in ok if r.price_per_graft_usd]
+        pages  = [r.pages_scraped for r in ok]
+        if prices: print(f"  Avg $/graft  : ${sum(prices)/len(prices):.2f}")
+        print(f"  Avg pages    : {sum(pages)/len(pages):.1f}")
+        print(f"  Free consult : {sum(r.offers_free_consultation for r in ok)}")
+        print(f"  Before/After : {sum(r.has_before_after for r in ok)}")
+        print(f"  With pricing : {sum(bool(r.price_range_raw) for r in ok)}")
+
+
+if __name__ == "__main__":
+    results = run_pipeline(TARGET_URLS)
+    save_results(results)

--- a/scripts/push-clinics.py
+++ b/scripts/push-clinics.py
@@ -1,0 +1,154 @@
+"""
+push-clinics.py
+---------------
+STEP 2 OF 2 in the clinic data pipeline.
+
+What this does:
+  Reads a clinics JSON file (output from clinic-website-scraper2.py) and upserts
+  each entry into the clinic_scraped_data table in Supabase, resolving the
+  clinic_id FK by matching on website_url from the clinics table.
+
+Usage:
+  python push-clinics.py output/clinics.json
+
+.env needs to be set up
+
+Requirements:
+    pip install supabase python-dotenv
+"""
+
+import json
+import os
+import sys
+from dotenv import load_dotenv
+from supabase import create_client, Client
+
+load_dotenv()
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_KEY")  # use service role key for upserts
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    sys.exit("Missing SUPABASE_URL or SUPABASE_SERVICE_KEY environment variables.")
+
+supabase: Client = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
+def load_clinics(path: str) -> list[dict]:
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def normalize_url(url: str) -> str:
+    """Lowercase and strip query params for consistent matching."""
+    return url.split("?")[0].lower()
+
+
+def fetch_clinic_id_map(supabase: Client) -> dict[str, str]:
+    """
+    Returns a dict of { normalized_url -> clinic uuid }
+    fetched from the clinics table.
+    """
+    result = supabase.table("clinics").select("id, website_url").execute()
+    if not result.data:
+        return {}
+    return {
+        normalize_url(row["website_url"]): row["id"]
+        for row in result.data
+        if row.get("website_url")
+    }
+
+
+def build_row(clinic: dict, clinic_id: str) -> dict:
+    """
+    Build the clinic_scraped_data row from a clinic JSON entry.
+    """
+    return {
+        "clinic_id": clinic_id,
+        "url": clinic["url"],
+        "name": clinic.get("name"),
+        "slug": clinic.get("slug"),
+        "address": clinic.get("address"),
+        "city": clinic.get("city"),
+        "country": clinic.get("country"),
+        "google_place_id": clinic.get("google_place_id") or None,
+        "description": clinic.get("description"),
+        "techniques": clinic.get("techniques") or [],
+        "services": clinic.get("services") or [],
+        "body_areas": clinic.get("body_areas") or [],
+        "languages_spoken": clinic.get("languages_spoken") or [],
+        "price_range_raw": clinic.get("price_range_raw"),
+        "price_per_graft_usd": clinic.get("price_per_graft_usd"),
+        "price_min_usd": clinic.get("price_min_usd"),
+        "price_max_usd": clinic.get("price_max_usd"),
+        "currency_noted": clinic.get("currency_noted"),
+        "financing_available": clinic.get("financing_available", False),
+        "price_confidence": clinic.get("price_confidence"),
+        "doctors": clinic.get("doctors") or [],
+        "certifications": clinic.get("certifications") or [],
+        "memberships": clinic.get("memberships") or [],
+        "accreditations": clinic.get("accreditations") or [],
+        "years_experience": clinic.get("years_experience"),
+        "years_established": clinic.get("years_established"),
+        "cases_performed": clinic.get("cases_performed"),
+        "success_rate_pct": clinic.get("success_rate_pct"),
+        "has_online_booking": clinic.get("has_online_booking", False),
+        "offers_free_consultation": clinic.get("offers_free_consultation", False),
+        "offers_virtual_consultation": clinic.get("offers_virtual_consultation", False),
+        "booking_url": clinic.get("booking_url") or None,
+        "has_before_after": clinic.get("has_before_after", False),
+        "data_quality": clinic.get("data_quality"),
+        "scraped_at": clinic.get("scraped_at"),
+        "cleaned_at": clinic.get("cleaned_at"),
+        "pages_scraped": clinic.get("pages_scraped"),
+        "scrape_ok": clinic.get("scrape_ok", False),
+        "error": clinic.get("error") or None,
+    }
+
+
+def push_clinics(json_path: str):
+    print(f"Loading clinics from {json_path}...")
+    clinics = load_clinics(json_path)
+    print(f"  {len(clinics)} entries found.")
+
+    print("Fetching clinic IDs from Supabase...")
+    clinic_id_map = fetch_clinic_id_map(supabase)
+    print(f"  {len(clinic_id_map)} clinics found in DB.")
+
+    rows_to_upsert = []
+    skipped = []
+
+    for clinic in clinics:
+        raw_url = clinic.get("url", "")
+        norm_url = normalize_url(raw_url)
+        clinic_id = clinic_id_map.get(norm_url)
+
+        if not clinic_id:
+            skipped.append(raw_url)
+            continue
+
+        rows_to_upsert.append(build_row(clinic, clinic_id))
+
+    if skipped:
+        print(f"\n⚠️  {len(skipped)} clinics had no matching row in the clinics table:")
+        for url in skipped:
+            print(f"    {url}")
+
+    if not rows_to_upsert:
+        print("\nNothing to upsert. Exiting.")
+        return
+
+    print(f"\nUpserting {len(rows_to_upsert)} rows into clinic_scraped_data...")
+    result = (
+        supabase.table("clinic_scraped_data")
+        .upsert(rows_to_upsert, on_conflict="url")
+        .execute()
+    )
+
+    inserted = len(result.data) if result.data else 0
+    print(f"✅ Done. {inserted} rows upserted.")
+
+
+if __name__ == "__main__":
+    json_path = sys.argv[1] if len(sys.argv) > 1 else "clinics_clean.json"
+    push_clinics(json_path)

--- a/tests/api/clinics-scraped-data.test.ts
+++ b/tests/api/clinics-scraped-data.test.ts
@@ -1,0 +1,139 @@
+/**
+ * tests/unit/api/clinics-scraped-data.test.ts
+ *
+ * Tests for clinic_scraped_data integration.
+ * Covers: description resolution, techniques, overview visibility logic
+ * added as part of the website-scraping feature.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Pure logic extracted from lib/api/clinics.ts ──────────────────────────────
+
+function resolveDescription(
+  scrapedData: { description: string | null } | null | undefined
+): string | null {
+  return scrapedData?.description ?? null;
+}
+
+function resolveTechniques(
+  scrapedData: { techniques?: string[] | null } | null | undefined
+): string[] {
+  return scrapedData?.techniques ?? [];
+}
+
+function shouldShowOverview(
+  description: string | null,
+  techniques: string[]
+): boolean {
+  return !!description || techniques.length > 0;
+}
+
+// Mirrors normalize_url() in scripts/push-clinics.py
+function normalizeUrl(url: string): string {
+  return url.split('?')[0].toLowerCase();
+}
+
+// ── Description resolution ─────────────────────────────────────────────────────
+
+describe('resolveDescription — clinic_scraped_data.description', () => {
+  it('returns scraped description for a clinic like AEK Hair Clinic', () => {
+    const scrapedData = {
+      description:
+        'Located in Turkey, AEK Hair Clinic specializes in high-quality hair transplants using FUT and FUE techniques.',
+    };
+    expect(resolveDescription(scrapedData)).toBe(scrapedData.description);
+  });
+
+  it('returns null for unscraped clinics like Dr. Cinik Clinic', () => {
+    // Clinic exists in clinics table but has no row in clinic_scraped_data
+    expect(resolveDescription(null)).toBeNull();
+  });
+
+  it('returns null when clinic_scraped_data row exists but description is null', () => {
+    expect(resolveDescription({ description: null })).toBeNull();
+  });
+
+  it('returns null when scrapedData is undefined (no join result)', () => {
+    expect(resolveDescription(undefined)).toBeNull();
+  });
+});
+
+// ── Techniques resolution ──────────────────────────────────────────────────────
+
+describe('resolveTechniques — clinic_scraped_data.techniques', () => {
+  it('returns techniques for Lenus Clinic which has FUE, DHI, Sapphire FUE', () => {
+    const scrapedData = { techniques: ['FUE', 'DHI', 'Sapphire FUE'] };
+    expect(resolveTechniques(scrapedData)).toEqual(['FUE', 'DHI', 'Sapphire FUE']);
+  });
+
+  it('returns empty array for clinics with no scraped data', () => {
+    expect(resolveTechniques(null)).toEqual([]);
+  });
+
+  it('returns empty array when techniques field is null', () => {
+    expect(resolveTechniques({ techniques: null })).toEqual([]);
+  });
+
+  it('returns empty array when techniques field is missing from scraped row', () => {
+    expect(resolveTechniques({})).toEqual([]);
+  });
+});
+
+// ── Overview section visibility ────────────────────────────────────────────────
+
+describe('shouldShowOverview — profileOverview feature flag logic', () => {
+  it('shows overview for AHD Clinic which has both description and techniques', () => {
+    const description = 'AHD Clinic, founded by Dr. Hakan Doğanay, is a pioneer in hair transplant Turkey.';
+    const techniques = ['DHI'];
+    expect(shouldShowOverview(description, techniques)).toBe(true);
+  });
+
+  it('shows overview when only description is present', () => {
+    expect(shouldShowOverview('A clinic in Istanbul.', [])).toBe(true);
+  });
+
+  it('shows overview when only techniques are present', () => {
+    expect(shouldShowOverview(null, ['FUE', 'FUT'])).toBe(true);
+  });
+
+  it('hides overview for unscraped clinics like Dr. Cinik Clinic', () => {
+    // No description, no techniques — Overview card should not render
+    expect(shouldShowOverview(null, [])).toBe(false);
+  });
+
+  it('hides overview when description is empty string', () => {
+    expect(shouldShowOverview('', [])).toBe(false);
+  });
+});
+
+// ── URL normalization (mirrors push-clinics.py normalize_url) ──────────────────
+
+describe('normalizeUrl — used to match clinics JSON to clinics table', () => {
+  it('strips UTM params from Vera Clinic URL', () => {
+    expect(
+      normalizeUrl('https://www.veraclinic.net/?utm_source=google&utm_medium=organic&utm_campaign=gmb-listing')
+    ).toBe('https://www.veraclinic.net/');
+  });
+
+  it('lowercases the URL for case-insensitive matching', () => {
+    expect(normalizeUrl('https://www.DrSerkanAygin.com/')).toBe(
+      'https://www.drserkanaygin.com/'
+    );
+  });
+
+  it('preserves trailing slash so lenusclinic.com/ matches DB row', () => {
+    expect(normalizeUrl('https://lenusclinic.com/')).toBe('https://lenusclinic.com/');
+  });
+
+  it('handles clinic URLs with paths like Memorial hospital', () => {
+    expect(
+      normalizeUrl('https://www.memorial.com.tr/hastane-ve-tip-merkezleri/sisli/')
+    ).toBe('https://www.memorial.com.tr/hastane-ve-tip-merkezleri/sisli/');
+  });
+
+  it('handles http clinics like estefavor and drterziler', () => {
+    expect(normalizeUrl('http://www.estefavor.com/')).toBe('http://www.estefavor.com/');
+    expect(normalizeUrl('http://drterziler.com/')).toBe('http://drterziler.com/');
+  });
+});

--- a/tests/components/OverviewSection.test.tsx
+++ b/tests/components/OverviewSection.test.tsx
@@ -1,52 +1,102 @@
-import { describe, it, expect } from 'vitest';
+/**
+ * tests/unit/components/OverviewSection.test.tsx
+ *
+ * Tests for OverviewSection component.
+ * Updated for website-scraping feature — yearsInOperation, proceduresPerformed,
+ * and languages have been removed from the UI. Techniques from clinic_scraped_data
+ * now replace procedures performed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+
+vi.mock('next/font/google', () => ({
+  Merriweather: () => ({ className: 'mocked-merriweather' }),
+}));
+
 import { OverviewSection } from '@/components/istanbulmedic-connect/profile/OverviewSection';
 
 describe('OverviewSection', () => {
   const defaultProps = {
-    specialties: ['Hair Transplant', 'Dental'],
-    yearsInOperation: 15,
-    proceduresPerformed: 50000,
-    languages: ['English', 'Turkish'],
-    description: 'A great clinic for medical tourism.',
+    specialties: ['Hair Transplant'],
+    yearsInOperation: null,
+    proceduresPerformed: null,
+    languages: [],
+    description: 'Located in Turkey, AEK Hair Clinic specializes in high-quality hair transplants using FUT and FUE techniques.',
+    techniques: ['FUE', 'FUT'],
   };
 
-  it('renders with full data', () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('renders the overview heading', () => {
     render(<OverviewSection {...defaultProps} />);
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+  });
 
+  it('renders specialties as badges', () => {
+    render(<OverviewSection {...defaultProps} specialties={['Hair Transplant', 'Beard Transplant']} />);
     expect(screen.getByText('Hair Transplant')).toBeInTheDocument();
-    expect(screen.getByText('Dental')).toBeInTheDocument();
-    expect(screen.getByText('15')).toBeInTheDocument();
-    expect(screen.getByText('50,000')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument(); // languages count
-    expect(screen.getByText('A great clinic for medical tourism.')).toBeInTheDocument();
+    expect(screen.getByText('Beard Transplant')).toBeInTheDocument();
   });
 
-  it('shows "Not available" for null yearsInOperation', () => {
-    render(<OverviewSection {...defaultProps} yearsInOperation={null} />);
+  // ── Description ────────────────────────────────────────────────────────────
 
-    const notAvailable = screen.getAllByText('Not available');
-    expect(notAvailable.length).toBeGreaterThanOrEqual(1);
+  it('renders description from clinic_scraped_data', () => {
+    render(<OverviewSection {...defaultProps} />);
+    expect(
+      screen.getByText(
+        'Located in Turkey, AEK Hair Clinic specializes in high-quality hair transplants using FUT and FUE techniques.'
+      )
+    ).toBeInTheDocument();
   });
 
-  it('shows "Not available" for null proceduresPerformed', () => {
-    render(<OverviewSection {...defaultProps} proceduresPerformed={null} />);
-
-    const notAvailable = screen.getAllByText('Not available');
-    expect(notAvailable.length).toBeGreaterThanOrEqual(1);
+  it('renders AHD Clinic description correctly', () => {
+    render(
+      <OverviewSection
+        {...defaultProps}
+        description="AHD Clinic, founded by Dr. Hakan Doğanay, is a pioneer in hair transplant Turkey with 22 years of experience."
+      />
+    );
+    expect(screen.getByText(/AHD Clinic, founded by Dr. Hakan/)).toBeInTheDocument();
   });
 
-  it('shows "Not available" for empty languages', () => {
-    render(<OverviewSection {...defaultProps} languages={[]} />);
-
-    const notAvailable = screen.getAllByText('Not available');
-    expect(notAvailable.length).toBeGreaterThanOrEqual(1);
+  it('does not crash when description is null', () => {
+    render(<OverviewSection {...defaultProps} description={null} />);
+    expect(screen.getByText('Overview')).toBeInTheDocument();
   });
 
-  it('renders empty specialties without crashing', () => {
+  // ── Techniques ─────────────────────────────────────────────────────────────
+
+  it('renders techniques joined as a string', () => {
+    render(<OverviewSection {...defaultProps} techniques={['FUE', 'DHI', 'Sapphire FUE']} />);
+    expect(screen.getByText('FUE, DHI, Sapphire FUE')).toBeInTheDocument();
+  });
+
+  it('renders single technique without comma', () => {
+    render(<OverviewSection {...defaultProps} techniques={['DHI']} />);
+    expect(screen.getByText('DHI')).toBeInTheDocument();
+  });
+
+  it('does not render techniques stat block when techniques is empty', () => {
+    render(<OverviewSection {...defaultProps} techniques={[]} />);
+    expect(screen.queryByText('Techniques')).not.toBeInTheDocument();
+  });
+  // ── Empty state ────────────────────────────────────────────────────────────
+
+  it('renders without crashing when specialties is empty', () => {
     render(<OverviewSection {...defaultProps} specialties={[]} />);
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+  });
 
-    // Should still render the section
+  it('renders without crashing for a fully unscraped clinic', () => {
+    render(
+      <OverviewSection
+        {...defaultProps}
+        description={null}
+        techniques={[]}
+        specialties={[]}
+      />
+    );
     expect(screen.getByText('Overview')).toBeInTheDocument();
   });
 });

--- a/tests/import-google-places.test.ts
+++ b/tests/import-google-places.test.ts
@@ -12,7 +12,11 @@ vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
 
 // ─── Mock Supabase ────────────────────────────────────────────────────────────
 const mockSingle = vi.fn()
-const mockSelect = vi.fn(() => ({ single: mockSingle }))
+const mockSelect = vi.fn(() => ({ 
+  single: mockSingle,
+  eq: vi.fn().mockReturnValue({ single: mockSingle }),
+  order: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ single: mockSingle }) }),
+}))
 const mockInsert = vi.fn(() => ({ select: mockSelect }))
 const mockUpdate = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) }))
 const mockDelete = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({}) }))


### PR DESCRIPTION
Frontend Changes
- OverviewSection displays scraped description and techniques
- Removes previously hardcoded placeholder text
- Hides the section entirely for clinics that have not been scraped (no description or techniques)
- Enabled profileOverview feature flag in filterConfig.ts
Scripts
- scripts/clinic-website-scraper2.py
- Scrapes clinic websites using Ollama (llama3) locally
- Outputs structured data to clinics.json
- scripts/push-clinics.py
- Upserts scraped data into clinic_scraped_data
- Resolves clinic_id by matching on clinic URL
Tests
- tests/api/clinics-scraped-data.test.ts
- Validates description and techniques resolution
- Ensures correct Overview visibility behavior
- Covers URL normalization using real clinic data
- tests/components/OverviewSection.test.tsx
- Updated to reflect removal of stats (years, procedures, languages)
- Adds coverage for techniques rendering
Notes
- Some clinics block scraping, don't fully trust scraped data
- Scraper requires Ollama + llama3 running locally. Reviewers do not need to run it to test this PR 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Lowest Rated" sorting option for clinic search results

* **Improvements**
  * Clinic profiles now display techniques and specialized services in the overview section
  * Replaced operation statistics with relevant medical techniques information
  * Enhanced data handling to gracefully support clinics with missing descriptions
  * Improved clinic information accuracy through automated data extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->