### PR TITLE
added more scraping options to get more than limit of 1k posts

### DIFF
--- a/app/api/redditPipeline/redditConfig.ts
+++ b/app/api/redditPipeline/redditConfig.ts
@@ -46,8 +46,18 @@ export interface RawRedditComment {
   parent_id: string
 }
 
+export type SortOrder = 'new' | 'top' | 'controversial' | 'hot' | 'rising'
+export type TimePeriod = 'hour' | 'day' | 'week' | 'month' | 'year' | 'all'
+
+export interface SortSlice {
+  sortOrder: SortOrder
+  timePeriod?: TimePeriod  // only applies to 'top' and 'controversial'
+}
+
 /** Options for fetchSubredditPosts */
 export interface FetchPostsOptions {
   maxPosts?: number
   lookbackDays?: number
+  sortOrder?: SortOrder
+  timePeriod?: TimePeriod
 }

--- a/app/api/redditPipeline/redditPipeline.ts
+++ b/app/api/redditPipeline/redditPipeline.ts
@@ -10,7 +10,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js'
-import { REDDIT_CONFIG, type RawRedditPost } from './redditConfig'
+import { REDDIT_CONFIG, type RawRedditPost, type SortSlice } from './redditConfig'
 import { fetchSubredditPosts, fetchPostComments } from './redditService'
 import { extractAndStoreSignals } from '../forumPipeline/deterministicExtractor'
 
@@ -27,6 +27,7 @@ export interface PipelineOptions {
   subreddits?: string[]
   maxPostsPerSubreddit?: number
   lookbackDays?: number
+  sortSlices?: SortSlice[]  // defaults to [{ sortOrder: 'new' }]
   includeComments?: boolean
   commentScoreThreshold?: number // Only fetch comments for posts above this score
   dryRun?: boolean
@@ -100,6 +101,7 @@ export async function runRedditPipeline(options: PipelineOptions = {}): Promise<
   const subreddits = options.subreddits ?? REDDIT_CONFIG.subreddits
   const maxPosts = options.maxPostsPerSubreddit ?? REDDIT_CONFIG.postsPerSubreddit
   const lookbackDays = options.lookbackDays ?? REDDIT_CONFIG.lookbackDays
+  const sortSlices = options.sortSlices ?? [{ sortOrder: 'new' as const }]
   const includeComments = options.includeComments ?? false
   const commentScoreThreshold = options.commentScoreThreshold ?? 10
   const dryRun = options.dryRun ?? false
@@ -141,21 +143,45 @@ export async function runRedditPipeline(options: PipelineOptions = {}): Promise<
   for (const subreddit of subreddits) {
     console.info(`[redditPipeline] Scraping r/${subreddit}...`)
 
-    let posts: RawRedditPost[]
-    try {
-      posts = await fetchSubredditPosts(subreddit, { maxPosts, lookbackDays })
-    } catch (err) {
-      const msg = `Failed to fetch r/${subreddit}: ${err instanceof Error ? err.message : err}`
-      console.error(`[redditPipeline] ${msg}`)
-      result.errors.push(msg)
-      continue
+    // Fetch all sort slices and deduplicate by post id
+    const seenIds = new Set<string>()
+    const posts: RawRedditPost[] = []
+    let fetchFailed = false
+
+    for (const slice of sortSlices) {
+      const label = slice.timePeriod ? `${slice.sortOrder}?t=${slice.timePeriod}` : slice.sortOrder
+      console.info(`[redditPipeline] r/${subreddit}: fetching /${label}...`)
+      try {
+        const batch = await fetchSubredditPosts(subreddit, {
+          maxPosts,
+          lookbackDays,
+          sortOrder: slice.sortOrder,
+          timePeriod: slice.timePeriod,
+        })
+        let newInSlice = 0
+        for (const post of batch) {
+          if (!seenIds.has(post.id)) {
+            seenIds.add(post.id)
+            posts.push(post)
+            newInSlice++
+          }
+        }
+        console.info(`[redditPipeline] r/${subreddit} /${label}: ${batch.length} fetched, ${newInSlice} unique`)
+      } catch (err) {
+        const msg = `Failed to fetch r/${subreddit} /${label}: ${err instanceof Error ? err.message : err}`
+        console.error(`[redditPipeline] ${msg}`)
+        result.errors.push(msg)
+        fetchFailed = true
+      }
     }
+
+    if (fetchFailed && posts.length === 0) continue
 
     result.postsFound += posts.length
     result.subredditsProcessed.push(subreddit)
 
     if (dryRun) {
-      console.info(`[redditPipeline] [DRY RUN] r/${subreddit}: ${posts.length} posts (not written)`)
+      console.info(`[redditPipeline] [DRY RUN] r/${subreddit}: ${posts.length} unique posts across ${sortSlices.length} sort(s) (not written)`)
       for (const p of posts.slice(0, 3)) {
         console.info(`  - ${p.title.slice(0, 80)} [score: ${p.score}]`)
       }

--- a/app/api/redditPipeline/redditPipeline.ts
+++ b/app/api/redditPipeline/redditPipeline.ts
@@ -152,9 +152,17 @@ export async function runRedditPipeline(options: PipelineOptions = {}): Promise<
       const label = slice.timePeriod ? `${slice.sortOrder}?t=${slice.timePeriod}` : slice.sortOrder
       console.info(`[redditPipeline] r/${subreddit}: fetching /${label}...`)
       try {
+        // For non-chronological sorts (top, controversial), lookbackDays filtering
+        // skips individual old posts rather than exiting early — but it still silently
+        // drops historically high-scoring posts if the caller left lookbackDays at the
+        // default. Pass Infinity unless the caller explicitly set a lookback.
+        const effectiveLookback = slice.sortOrder === 'new'
+          ? lookbackDays
+          : (options.lookbackDays !== undefined ? lookbackDays : Infinity)
+
         const batch = await fetchSubredditPosts(subreddit, {
           maxPosts,
-          lookbackDays,
+          lookbackDays: effectiveLookback,
           sortOrder: slice.sortOrder,
           timePeriod: slice.timePeriod,
         })

--- a/app/api/redditPipeline/redditService.ts
+++ b/app/api/redditPipeline/redditService.ts
@@ -99,10 +99,15 @@ export async function fetchSubredditPosts(
 
       const p = child.data as Record<string, unknown>
 
-      // Skip posts outside the lookback window (port of time_limit_days check)
+      // Skip posts outside the lookback window
       if (typeof p.created_utc === 'number' && p.created_utc < cutoffUtc) {
-        console.info(`[reddit] Reached lookback cutoff in r/${subreddit}`)
-        return posts // Sorted by new — once we hit the cutoff, remaining posts are older
+        if (sortOrder === 'new') {
+          // Chronological order — all remaining posts are older, safe to exit early
+          console.info(`[reddit] Reached lookback cutoff in r/${subreddit}`)
+          return posts
+        }
+        // Score/controversy order — older posts can appear anywhere, skip individually
+        continue
       }
 
       if (!p.id || !p.author || p.author === '[deleted]') continue

--- a/app/api/redditPipeline/redditService.ts
+++ b/app/api/redditPipeline/redditService.ts
@@ -74,6 +74,8 @@ export async function fetchSubredditPosts(
 ): Promise<RawRedditPost[]> {
   const maxPosts = options.maxPosts ?? REDDIT_CONFIG.postsPerSubreddit
   const lookbackDays = options.lookbackDays ?? REDDIT_CONFIG.lookbackDays
+  const sortOrder = options.sortOrder ?? 'new'
+  const timePeriod = options.timePeriod
   const cutoffUtc = Date.now() / 1000 - lookbackDays * 86400
 
   const posts: RawRedditPost[] = []
@@ -81,7 +83,8 @@ export async function fetchSubredditPosts(
   const maxPages = 20 // safety limit (same as reddit-auto max_requests = 20)
 
   for (let page = 0; page < maxPages && posts.length < maxPosts; page++) {
-    let url = `${REDDIT_CONFIG.baseUrl}/r/${subreddit}/new.json?limit=100`
+    let url = `${REDDIT_CONFIG.baseUrl}/r/${subreddit}/${sortOrder}.json?limit=100`
+    if (timePeriod && (sortOrder === 'top' || sortOrder === 'controversial')) url += `&t=${timePeriod}`
     if (after) url += `&after=${after}`
 
     const data = await makeRedditRequest(url) as { data?: { children?: { data: unknown }[]; after?: string | null } } | null

--- a/scripts/reddit-scrape-subreddits.ts
+++ b/scripts/reddit-scrape-subreddits.ts
@@ -8,6 +8,12 @@
  *   npx tsx scripts/reddit-scrape-subreddits.ts --dry-run
  *   npx tsx scripts/reddit-scrape-subreddits.ts --subreddits HairTransplants,TurkeyHairTransplant
  *   npx tsx scripts/reddit-scrape-subreddits.ts --max-posts 50 --lookback-days 180
+ *
+ * Sort slices (comma-separated, each optionally with :timePeriod):
+ *   npx tsx scripts/reddit-scrape-subreddits.ts --sorts new,top:all,controversial:all
+ *   npx tsx scripts/reddit-scrape-subreddits.ts --sorts top:year
+ *
+ * timePeriod values: hour, day, week, month, year, all
  */
 
 import dotenv from 'dotenv'
@@ -21,6 +27,7 @@ if (missingEnv.length > 0) {
 }
 
 import { runRedditPipeline } from '../app/api/redditPipeline/redditPipeline'
+import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline/redditConfig'
 
 // ── Parse CLI args ────────────────────────────────────────────────────────────
 
@@ -35,6 +42,15 @@ function getArg(flag: string): string | undefined {
 const subredditsArg = getArg('--subreddits')
 const maxPostsArg = getArg('--max-posts')
 const lookbackArg = getArg('--lookback-days')
+const sortsArg = getArg('--sorts')
+
+// Parse "--sorts new,top:all,controversial:all" into SortSlice[]
+const sortSlices: SortSlice[] | undefined = sortsArg
+  ? sortsArg.split(',').map(s => {
+      const [sortOrder, timePeriod] = s.trim().split(':')
+      return { sortOrder: sortOrder as SortOrder, timePeriod: timePeriod as TimePeriod | undefined }
+    })
+  : undefined
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
@@ -47,6 +63,7 @@ async function main() {
     subreddits: subredditsArg ? subredditsArg.split(',').map(s => s.trim()) : undefined,
     maxPostsPerSubreddit: maxPostsArg ? parseInt(maxPostsArg) : undefined,
     lookbackDays: lookbackArg ? parseInt(lookbackArg) : undefined,
+    sortSlices,
     dryRun,
   })
 

--- a/tests/api/redditPipeline/redditPipeline.test.ts
+++ b/tests/api/redditPipeline/redditPipeline.test.ts
@@ -210,6 +210,102 @@ describe('runRedditPipeline', () => {
     })
   })
 
+  // ── Sort slices ─────────────────────────────────────────────────────────────
+
+  describe('sortSlices', () => {
+    it('calls fetchSubredditPosts once per slice', async () => {
+      mockFetchSubredditPosts
+        .mockResolvedValueOnce([makePost('p1')])   // new
+        .mockResolvedValueOnce([makePost('p2')])   // top:all
+        .mockResolvedValueOnce([makePost('p3')])   // controversial:all
+
+      const chain = makeChain({ data: { id: 'hub-uuid' }, error: null })
+      mockFrom.mockReturnValue(chain)
+
+      const result = await runRedditPipeline({
+        subreddits: ['HairTransplants'],
+        sortSlices: [
+          { sortOrder: 'new' },
+          { sortOrder: 'top', timePeriod: 'all' },
+          { sortOrder: 'controversial', timePeriod: 'all' },
+        ],
+        dryRun: false,
+      })
+
+      expect(mockFetchSubredditPosts).toHaveBeenCalledTimes(3)
+      expect(result.postsFound).toBe(3)
+    })
+
+    it('deduplicates posts that appear in multiple slices', async () => {
+      const sharedPost = makePost('shared')
+      mockFetchSubredditPosts
+        .mockResolvedValueOnce([sharedPost, makePost('unique1')])  // new
+        .mockResolvedValueOnce([sharedPost, makePost('unique2')])  // top:all — sharedPost is a duplicate
+
+      const chain = makeChain({ data: { id: 'hub-uuid' }, error: null })
+      mockFrom.mockReturnValue(chain)
+
+      const result = await runRedditPipeline({
+        subreddits: ['HairTransplants'],
+        sortSlices: [{ sortOrder: 'new' }, { sortOrder: 'top', timePeriod: 'all' }],
+        dryRun: false,
+      })
+
+      // 3 unique posts despite 4 total fetched (sharedPost counted once)
+      expect(result.postsFound).toBe(3)
+    })
+
+    it('deduplication across slices prevents double extraction of same post', async () => {
+      const sharedPost = makePost('shared')
+      mockFetchSubredditPosts
+        .mockResolvedValueOnce([sharedPost])
+        .mockResolvedValueOnce([sharedPost])  // same post in second slice
+
+      const chain = makeChain({ data: { id: 'hub-uuid' }, error: null })
+      mockFrom.mockReturnValue(chain)
+
+      await runRedditPipeline({
+        subreddits: ['HairTransplants'],
+        sortSlices: [{ sortOrder: 'new' }, { sortOrder: 'top', timePeriod: 'all' }],
+        dryRun: false,
+      })
+
+      // extractAndStoreSignals should only be called once for the shared post
+      expect(mockExtractAndStoreSignals).toHaveBeenCalledTimes(1)
+    })
+
+    it('defaults to a single new slice when sortSlices is not provided', async () => {
+      mockFetchSubredditPosts.mockResolvedValueOnce([makePost('p1')])
+      const chain = makeChain({ data: { id: 'hub-uuid' }, error: null })
+      mockFrom.mockReturnValue(chain)
+
+      await runRedditPipeline({ subreddits: ['HairTransplants'], dryRun: false })
+
+      expect(mockFetchSubredditPosts).toHaveBeenCalledTimes(1)
+      expect(mockFetchSubredditPosts).toHaveBeenCalledWith(
+        'HairTransplants',
+        expect.objectContaining({ sortOrder: 'new' })
+      )
+    })
+
+    it('passes sortOrder and timePeriod to fetchSubredditPosts', async () => {
+      mockFetchSubredditPosts.mockResolvedValueOnce([])
+      const chain = makeChain({ data: { id: 'uuid' }, error: null })
+      mockFrom.mockReturnValue(chain)
+
+      await runRedditPipeline({
+        subreddits: ['HairTransplants'],
+        sortSlices: [{ sortOrder: 'top', timePeriod: 'all' }],
+        dryRun: true,
+      })
+
+      expect(mockFetchSubredditPosts).toHaveBeenCalledWith(
+        'HairTransplants',
+        expect.objectContaining({ sortOrder: 'top', timePeriod: 'all' })
+      )
+    })
+  })
+
   // ── Error handling ──────────────────────────────────────────────────────────
 
   describe('error handling', () => {

--- a/tests/api/redditPipeline/redditService.test.ts
+++ b/tests/api/redditPipeline/redditService.test.ts
@@ -105,7 +105,7 @@ describe('fetchSubredditPosts', () => {
     expect(result).toHaveLength(3)
   })
 
-  it('stops when a post falls outside the lookback window', async () => {
+  it('stops when a post falls outside the lookback window (new sort — chronological early exit)', async () => {
     const recentPost = makePost({ id: 'recent', created_utc: NOW_UTC - 86400 })      // 1 day ago
     const oldPost = makePost({ id: 'old', created_utc: NOW_UTC - 100 * 86400 })      // 100 days ago
 
@@ -114,7 +114,28 @@ describe('fetchSubredditPosts', () => {
       json: async () => makeSubredditResponse([recentPost, oldPost], 't3_more'),
     }))
 
-    const result = await fetchSubredditPosts('HairTransplants', { maxPosts: 10, lookbackDays: 30 })
+    const result = await fetchSubredditPosts('HairTransplants', { maxPosts: 10, lookbackDays: 30, sortOrder: 'new' })
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('recent')
+  })
+
+  it('skips old posts individually for top sort when an explicit lookbackDays is provided', async () => {
+    // In normal usage top:all defaults to Infinity lookback (no cutoff).
+    // But if a caller explicitly passes lookbackDays, old posts should be skipped
+    // individually (continue) not cause an early exit (return) — because top is
+    // ordered by score, not time, so an old post anywhere in the list should not
+    // abort the entire fetch.
+    const oldPost = makePost({ id: 'old', created_utc: NOW_UTC - 500 * 86400, score: 999 })   // 500 days ago, high score
+    const recentPost = makePost({ id: 'recent', created_utc: NOW_UTC - 86400, score: 10 })    // 1 day ago, lower score
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: async () => makeSubredditResponse([oldPost, recentPost]),
+    }))
+
+    // With sortOrder: 'new' this would early-exit after oldPost and return []
+    // With sortOrder: 'top' it should skip oldPost and still return recentPost
+    const result = await fetchSubredditPosts('HairTransplants', { maxPosts: 10, lookbackDays: 30, sortOrder: 'top' })
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('recent')
   })


### PR DESCRIPTION
## Summary
- Add multi-sort scraping to get beyond Reddit's ~1,000-post pagination cap: pass `--sorts new,top:all,controversial:all` to scrape different slices and deduplicate in-memory before writing
- Also added to tests

Future Steps
- look into scraping from Pushshift/Arctic Shift - a third-party Reddit archive.

## Manual testing
```bash
# dry-run with 3 sort slices
npx tsx scripts/reddit-scrape-subreddits.ts \
  --subreddits HairTransplants --max-posts 50 \
  --sorts new,top:all,controversial:all --dry-run



