### PR TITLE
Feature/consultations

### DIFF
--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+// GET /api/bookmarks — list all bookmarks for the logged-in user
+export async function GET() {
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id')
+    .eq('auth_id', user.id)
+    .maybeSingle()
+
+  if (!userRow) {
+    return NextResponse.json({ bookmarks: [] })
+  }
+
+  // 1. Fetch bookmarks with clinic basic info + google places rating
+  const { data, error } = await supabase
+    .from('user_bookmarks')
+    .select(`
+      id,
+      clinic_id,
+      clinics (
+        id,
+        display_name,
+        primary_city,
+        primary_country,
+        clinic_google_places (
+          rating,
+          user_ratings_total
+        )
+      )
+    `)
+    .eq('user_id', userRow.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('GET /api/bookmarks error:', error)
+    return NextResponse.json({ error: 'Failed to fetch bookmarks' }, { status: 500 })
+  }
+
+  const clinicIds = (data ?? []).map((b) => b.clinic_id)
+
+  // 2. Fetch primary images for these clinics in one query
+  const imageMap: Record<string, string | null> = {}
+  if (clinicIds.length > 0) {
+    const { data: mediaRows } = await supabase
+      .from('clinic_media')
+      .select('clinic_id, url')
+      .in('clinic_id', clinicIds)
+      .eq('media_type', 'image')
+      .eq('is_primary', true)
+
+    for (const m of mediaRows ?? []) {
+      imageMap[m.clinic_id] = m.url
+    }
+  }
+
+  // 3. Check which clinics already have a pending consultation
+  let requestedIds: string[] = []
+  if (clinicIds.length > 0) {
+    const { data: consultations } = await supabase
+      .from('consultations')
+      .select('clinic_id')
+      .eq('user_id', userRow.id)
+      .in('clinic_id', clinicIds)
+      .eq('status', 'pending')
+    requestedIds = (consultations ?? []).map((c) => c.clinic_id)
+  }
+
+  const bookmarks = (data ?? []).map((b) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clinic = b.clinics as any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const googlePlaces = Array.isArray(clinic?.clinic_google_places)
+      ? clinic.clinic_google_places[0]
+      : clinic?.clinic_google_places
+
+    return {
+      bookmarkId: b.id,
+      clinicId: b.clinic_id,
+      name: clinic?.display_name ?? '',
+      location: clinic
+        ? `${clinic.primary_city}, ${clinic.primary_country}`
+        : '',
+      image: imageMap[b.clinic_id] ?? null,
+      rating: googlePlaces?.rating ?? null,
+      reviewCount: googlePlaces?.user_ratings_total ?? 0,
+      consultationRequested: requestedIds.includes(b.clinic_id),
+    }
+  })
+
+  return NextResponse.json({ bookmarks })
+}
+
+// POST /api/bookmarks — { clinicId } → save bookmark
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let clinicId: string
+  try {
+    const body = await request.json()
+    clinicId = body.clinicId
+    if (!clinicId) throw new Error('missing clinicId')
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id')
+    .eq('auth_id', user.id)
+    .maybeSingle()
+
+  if (!userRow) {
+    return NextResponse.json({ error: 'User record not found' }, { status: 404 })
+  }
+
+  const { data, error } = await supabase
+    .from('user_bookmarks')
+    .insert({ user_id: userRow.id, clinic_id: clinicId })
+    .select('id')
+    .single()
+
+  if (error) {
+    // 23505 = unique violation — already bookmarked, treat as success
+    if (error.code === '23505') {
+      return NextResponse.json({ bookmarkId: null, alreadyExists: true })
+    }
+    console.error('POST /api/bookmarks error:', error)
+    return NextResponse.json({ error: 'Failed to save bookmark' }, { status: 500 })
+  }
+
+  return NextResponse.json({ bookmarkId: data.id })
+}
+
+// DELETE /api/bookmarks — { clinicId } → remove bookmark
+export async function DELETE(request: NextRequest) {
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let clinicId: string
+  try {
+    const body = await request.json()
+    clinicId = body.clinicId
+    if (!clinicId) throw new Error('missing clinicId')
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id')
+    .eq('auth_id', user.id)
+    .maybeSingle()
+
+  if (!userRow) {
+    return NextResponse.json({ error: 'User record not found' }, { status: 404 })
+  }
+
+  const { error } = await supabase
+    .from('user_bookmarks')
+    .delete()
+    .eq('user_id', userRow.id)
+    .eq('clinic_id', clinicId)
+
+  if (error) {
+    console.error('DELETE /api/bookmarks error:', error)
+    return NextResponse.json({ error: 'Failed to remove bookmark' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/app/api/clinics/route.ts
+++ b/app/api/clinics/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getClinics } from '@/lib/api/clinics'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl
+    const search = searchParams.get('search') ?? undefined
+    const pageSize = Math.min(Number(searchParams.get('pageSize') ?? '6'), 20)
+
+    const result = await getClinics({
+      searchQuery: search,
+      pageSize,
+      page: 1,
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: result.clinics.map((c) => ({
+        id: c.id,
+        name: c.name,
+        location: c.location,
+        image: c.image,
+      })),
+      total: result.total,
+    })
+  } catch (error) {
+    console.error('GET /api/clinics error:', error)
+    return NextResponse.json({ success: false, error: 'Failed to fetch clinics' }, { status: 500 })
+  }
+}

--- a/app/api/consultations/route.ts
+++ b/app/api/consultations/route.ts
@@ -35,12 +35,12 @@ export async function POST(request: NextRequest) {
   const sb = supabase as any
   const [
     { data: clinicRows },
-    { data: qual },
-    { data: treat },
-    { data: profile },
-    { data: transplants },
-    { data: surgeries },
-    { data: photos },
+    { data: qual,        error: qualErr },
+    { data: treat,       error: treatErr },
+    { data: profile,     error: profileErr },
+    { data: transplants, error: transplantsErr },
+    { data: surgeries,   error: surgeriesErr },
+    { data: photos,      error: photosErr },
   ] = await Promise.all([
     supabase.from('clinics').select('id, display_name').in('id', clinicIds),
     sb.from('user_qualification').select('age_tier, country, budget_tier, timeline, whatsapp_number').eq('user_id', userRow.id).maybeSingle(),
@@ -51,16 +51,47 @@ export async function POST(request: NextRequest) {
     sb.from('user_photos').select('photo_view, storage_url').eq('user_id', userRow.id),
   ])
 
+  const failedQueries = Object.entries({ qualErr, treatErr, profileErr, transplantsErr, surgeriesErr, photosErr })
+    .filter(([, e]) => e != null)
+    .map(([k]) => k)
+  if (failedQueries.length > 0) {
+    console.error('passport data fetch partial failure — email will have incomplete profile', {
+      userId: userRow.id,
+      failedQueries,
+    })
+  }
+
   const clinicNameMap: Record<string, string> = {}
   for (const c of clinicRows ?? []) {
     clinicNameMap[c.id] = c.display_name
   }
 
-  // Insert one row per clinic — skip duplicates (pending unique index)
-  const rows = clinicIds.map((clinicId) => ({
+  // Pre-filter clinics that already have a pending consultation — avoids
+  // a partial-index conflict aborting the entire batch insert.
+  const { data: existingPending } = await supabase
+    .from('consultations')
+    .select('clinic_id')
+    .eq('user_id', userRow.id)
+    .in('clinic_id', clinicIds)
+    .eq('status', 'pending')
+
+  const existingIds = new Set((existingPending ?? []).map((r) => r.clinic_id))
+  const newClinicIds = clinicIds.filter((id) => !existingIds.has(id))
+
+  if (newClinicIds.length === 0) {
+    return NextResponse.json({ created: 0, skipped: clinicIds.length })
+  }
+
+  const userEmail = userRow.email ?? user.email ?? ''
+  if (!userEmail) {
+    console.error('POST /api/consultations — no email on user record', { userId: userRow.id })
+    return NextResponse.json({ error: 'User email not found' }, { status: 500 })
+  }
+
+  const rows = newClinicIds.map((clinicId) => ({
     user_id: userRow.id,
     clinic_id: clinicId,
-    user_email: userRow.email ?? user.email ?? '',
+    user_email: userEmail,
     user_name: userRow.name ?? null,
     status: 'pending' as const,
   }))
@@ -71,10 +102,8 @@ export async function POST(request: NextRequest) {
     .select('id, clinic_id')
 
   if (insertError) {
-    if (insertError.code !== '23505') {
-      console.error('POST /api/consultations insert error:', insertError)
-      return NextResponse.json({ error: 'Failed to create consultations' }, { status: 500 })
-    }
+    console.error('POST /api/consultations insert error:', insertError)
+    return NextResponse.json({ error: 'Failed to create consultations' }, { status: 500 })
   }
 
   const createdIds = (inserted ?? []).map((r) => r.clinic_id)
@@ -119,15 +148,27 @@ export async function POST(request: NextRequest) {
       })),
     }
 
-    await sendConsultationRequest({
-      userName: userRow.name ?? user.email ?? 'Unknown',
-      userEmail: userRow.email ?? user.email ?? '',
-      clinicNames,
-      passport,
-    }).catch((e) => console.error('sendConsultationRequest error:', e))
+    let emailSent = true
+    try {
+      await sendConsultationRequest({
+        userName: userRow.name ?? user.email ?? 'Unknown',
+        userEmail: userRow.email ?? user.email ?? '',
+        clinicNames,
+        passport,
+      })
+    } catch (e) {
+      emailSent = false
+      console.error('sendConsultationRequest failed — consultations saved but team not notified', {
+        userId: userRow.id,
+        clinicIds: createdIds,
+        error: e,
+      })
+    }
+
+    return NextResponse.json({ created: createdIds.length, skipped: skippedIds.length, emailSent })
   }
 
-  return NextResponse.json({ created: createdIds.length, skipped: skippedIds.length })
+  return NextResponse.json({ created: createdIds.length, skipped: skippedIds.length, emailSent: true })
 }
 
 // GET /api/consultations — list all consultations for the logged-in user

--- a/app/api/consultations/route.ts
+++ b/app/api/consultations/route.ts
@@ -1,0 +1,204 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { sendConsultationRequest, type ConsultationPassport } from '@/lib/email/sendConsultationRequest'
+
+// POST /api/consultations — { clinicIds: string[] } → create records + send email
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let clinicIds: string[]
+  try {
+    const body = await request.json()
+    clinicIds = body.clinicIds
+    if (!Array.isArray(clinicIds) || clinicIds.length === 0) throw new Error('invalid')
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id, name, email')
+    .eq('auth_id', user.id)
+    .maybeSingle()
+
+  if (!userRow) {
+    return NextResponse.json({ error: 'User record not found' }, { status: 404 })
+  }
+
+  // Fetch clinic names + passport data in parallel
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb = supabase as any
+  const [
+    { data: clinicRows },
+    { data: qual },
+    { data: treat },
+    { data: profile },
+    { data: transplants },
+    { data: surgeries },
+    { data: photos },
+  ] = await Promise.all([
+    supabase.from('clinics').select('id, display_name').in('id', clinicIds),
+    sb.from('user_qualification').select('age_tier, country, budget_tier, timeline, whatsapp_number').eq('user_id', userRow.id).maybeSingle(),
+    sb.from('user_treatment_profiles').select('norwood_scale, hair_loss_duration_years, donor_area_quality, donor_area_availability, desired_density, had_prior_transplant, allergies, medications, other_conditions').eq('user_id', userRow.id).maybeSingle(),
+    sb.from('user_profiles').select('gender').eq('user_id', userRow.id).maybeSingle(),
+    sb.from('user_prior_transplants').select('year, estimated_grafts, clinic_country').eq('user_id', userRow.id),
+    sb.from('user_prior_surgeries').select('surgery_type, year, notes').eq('user_id', userRow.id),
+    sb.from('user_photos').select('photo_view, storage_url').eq('user_id', userRow.id),
+  ])
+
+  const clinicNameMap: Record<string, string> = {}
+  for (const c of clinicRows ?? []) {
+    clinicNameMap[c.id] = c.display_name
+  }
+
+  // Insert one row per clinic — skip duplicates (pending unique index)
+  const rows = clinicIds.map((clinicId) => ({
+    user_id: userRow.id,
+    clinic_id: clinicId,
+    user_email: userRow.email ?? user.email ?? '',
+    user_name: userRow.name ?? null,
+    status: 'pending' as const,
+  }))
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('consultations')
+    .insert(rows)
+    .select('id, clinic_id')
+
+  if (insertError) {
+    if (insertError.code !== '23505') {
+      console.error('POST /api/consultations insert error:', insertError)
+      return NextResponse.json({ error: 'Failed to create consultations' }, { status: 500 })
+    }
+  }
+
+  const createdIds = (inserted ?? []).map((r) => r.clinic_id)
+  const skippedIds = clinicIds.filter((id) => !createdIds.includes(id))
+
+  if (createdIds.length > 0) {
+    const clinicNames = createdIds.map((id) => clinicNameMap[id] ?? id)
+
+    const passport: ConsultationPassport = {
+      // Profile
+      ageTier: qual?.age_tier ?? null,
+      gender: profile?.gender ?? null,
+      country: qual?.country ?? null,
+      budgetTier: qual?.budget_tier ?? null,
+      timeline: qual?.timeline ?? null,
+      whatsApp: qual?.whatsapp_number ?? null,
+      // Hair loss
+      norwoodScale: treat?.norwood_scale ?? null,
+      durationYears: treat?.hair_loss_duration_years ?? null,
+      donorAreaQuality: treat?.donor_area_quality ?? null,
+      donorAreaAvailability: treat?.donor_area_availability ?? null,
+      desiredDensity: treat?.desired_density ?? null,
+      hadPriorTransplant: treat?.had_prior_transplant ?? null,
+      priorTransplants: (transplants ?? []).map((t: { year: number; estimated_grafts: number; clinic_country: string }) => ({
+        year: t.year,
+        estimatedGrafts: t.estimated_grafts,
+        clinicCountry: t.clinic_country,
+      })),
+      // Medical
+      allergies: treat?.allergies ?? [],
+      medications: treat?.medications ?? [],
+      otherConditions: treat?.other_conditions ?? [],
+      priorSurgeries: (surgeries ?? []).map((s: { surgery_type: string; year: number; notes?: string }) => ({
+        type: s.surgery_type,
+        year: s.year,
+        notes: s.notes ?? undefined,
+      })),
+      // Photos
+      photos: (photos ?? []).map((ph: { photo_view: string; storage_url: string }) => ({
+        view: ph.photo_view,
+        url: ph.storage_url,
+      })),
+    }
+
+    await sendConsultationRequest({
+      userName: userRow.name ?? user.email ?? 'Unknown',
+      userEmail: userRow.email ?? user.email ?? '',
+      clinicNames,
+      passport,
+    }).catch((e) => console.error('sendConsultationRequest error:', e))
+  }
+
+  return NextResponse.json({ created: createdIds.length, skipped: skippedIds.length })
+}
+
+// GET /api/consultations — list all consultations for the logged-in user
+export async function GET() {
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: userRow } = await supabase
+    .from('users')
+    .select('id')
+    .eq('auth_id', user.id)
+    .maybeSingle()
+
+  if (!userRow) {
+    return NextResponse.json({ consultations: [] })
+  }
+
+  const { data, error } = await supabase
+    .from('consultations')
+    .select(`
+      id,
+      status,
+      created_at,
+      clinic_id,
+      clinics (
+        id,
+        display_name,
+        primary_city,
+        primary_country
+      )
+    `)
+    .eq('user_id', userRow.id)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('GET /api/consultations error:', error)
+    return NextResponse.json({ error: 'Failed to fetch consultations' }, { status: 500 })
+  }
+
+  const clinicIds = (data ?? []).map((c) => c.clinic_id).filter(Boolean)
+  const imageMap: Record<string, string | null> = {}
+  if (clinicIds.length > 0) {
+    const { data: mediaRows } = await supabase
+      .from('clinic_media')
+      .select('clinic_id, url')
+      .in('clinic_id', clinicIds)
+      .eq('media_type', 'image')
+      .eq('is_primary', true)
+
+    for (const m of mediaRows ?? []) {
+      imageMap[m.clinic_id] = m.url
+    }
+  }
+
+  const consultations = (data ?? []).map((c) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clinic = c.clinics as any
+    return {
+      id: c.id,
+      status: c.status,
+      createdAt: c.created_at,
+      clinicId: c.clinic_id,
+      clinicName: clinic?.display_name ?? '',
+      clinicLocation: clinic ? `${clinic.primary_city}, ${clinic.primary_country}` : '',
+      clinicImage: imageMap[c.clinic_id] ?? null,
+    }
+  })
+
+  return NextResponse.json({ consultations })
+}

--- a/app/api/consultations/route.ts
+++ b/app/api/consultations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { sendConsultationRequest, type ConsultationPassport } from '@/lib/email/sendConsultationRequest'
+import { sendConsultationRequest, sendConsultationConfirmation, type ConsultationPassport } from '@/lib/email/sendConsultationRequest'
 
 // POST /api/consultations — { clinicIds: string[] } → create records + send email
 export async function POST(request: NextRequest) {
@@ -155,17 +155,18 @@ export async function POST(request: NextRequest) {
       })),
     }
 
+    const userName = userRow.name ?? user.email ?? 'Unknown'
+    const emailParams = { userName, userEmail, clinicNames }
+
     let emailSent = true
     try {
-      await sendConsultationRequest({
-        userName: userRow.name ?? user.email ?? 'Unknown',
-        userEmail: userRow.email ?? user.email ?? '',
-        clinicNames,
-        passport,
-      })
+      await Promise.all([
+        sendConsultationRequest({ ...emailParams, passport }),
+        sendConsultationConfirmation(emailParams),
+      ])
     } catch (e) {
       emailSent = false
-      console.error('sendConsultationRequest failed — consultations saved but team not notified', {
+      console.error('consultation email(s) failed — consultations saved but notifications incomplete', {
         userId: userRow.id,
         clinicIds: createdIds,
         error: e,

--- a/app/api/consultations/route.ts
+++ b/app/api/consultations/route.ts
@@ -14,7 +14,9 @@ export async function POST(request: NextRequest) {
   let clinicIds: string[]
   try {
     const body = await request.json()
-    clinicIds = body.clinicIds
+    clinicIds = Array.isArray(body.clinicIds)
+      ? Array.from(new Set(body.clinicIds.filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)))
+      : []
     if (!Array.isArray(clinicIds) || clinicIds.length === 0) throw new Error('invalid')
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
@@ -68,12 +70,17 @@ export async function POST(request: NextRequest) {
 
   // Pre-filter clinics that already have a pending consultation — avoids
   // a partial-index conflict aborting the entire batch insert.
-  const { data: existingPending } = await supabase
+  const { data: existingPending, error: existingPendingError } = await supabase
     .from('consultations')
     .select('clinic_id')
     .eq('user_id', userRow.id)
     .in('clinic_id', clinicIds)
     .eq('status', 'pending')
+
+  if (existingPendingError) {
+    console.error('POST /api/consultations existing-pending lookup error:', existingPendingError)
+    return NextResponse.json({ error: 'Failed to check existing consultations' }, { status: 500 })
+  }
 
   const existingIds = new Set((existingPending ?? []).map((r) => r.clinic_id))
   const newClinicIds = clinicIds.filter((id) => !existingIds.has(id))

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -220,25 +220,8 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      // Decide where to send the user
-      let destination = next;
-      if (next === '/profile') {
-        // No specific destination — check if new user needs onboarding
-        const { data: freshUserRow } = await s
-          .from('users')
-          .select('id')
-          .eq('auth_id', data.user.id)
-          .maybeSingle();
-        const { data: qualRow } = freshUserRow
-          ? await s
-              .from('user_qualification')
-              .select('terms_accepted')
-              .eq('user_id', freshUserRow.id)
-              .maybeSingle()
-          : { data: null };
-        const hasConsented = qualRow?.terms_accepted === true;
-        destination = hasConsented ? '/profile' : '/profile/get-started';
-      }
+      // Decide where to send the user — always honour the next cookie
+      const destination = next;
 
       const redirectResponse = NextResponse.redirect(`${origin}${destination}`);
       cookieMutations.forEach(({ name, value, options }) =>

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -166,7 +166,7 @@ export async function GET(request: NextRequest) {
     .split(';')
     .map(c => c.trim())
     .find(c => c.startsWith('auth_redirect_next='))
-    ?.split('=')[1];
+    ?.split('=').slice(1).join('=');
   const decodedCookieNext = cookieNext ? decodeURIComponent(cookieNext) : null;
 
   const legacyPaths = ['/profile/treatment-profile'];

--- a/app/auth/login/LoginPageClient.tsx
+++ b/app/auth/login/LoginPageClient.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { useAuth } from "@/contexts/AuthContext"
+import { createClient } from "@/lib/supabase/client"
+
+const IS_LOCAL_SUPABASE = process.env.NEXT_PUBLIC_SUPABASE_URL?.startsWith("http://127.0.0.1")
 
 const LoginPageClient = () => {
   const router = useRouter()
@@ -11,6 +14,8 @@ const LoginPageClient = () => {
 
   const [isLoading, setIsLoading] = useState(false)
   const [manualError, setManualError] = useState<string | null>(null)
+  const [devEmail, setDevEmail] = useState("")
+  const [devPassword, setDevPassword] = useState("")
 
   const next = searchParams.get("next") ?? "/profile"
 
@@ -27,6 +32,22 @@ const LoginPageClient = () => {
       router.push(next)
     }
   }, [loading, isAuthenticated, next, router])
+
+  const handleDevLogin = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setManualError(null)
+    setIsLoading(true)
+    try {
+      const supabase = createClient()
+      if (!supabase) throw new Error("Supabase not configured")
+      const { error } = await supabase.auth.signInWithPassword({ email: devEmail, password: devPassword })
+      if (error) throw error
+      router.push(next)
+    } catch (err) {
+      setManualError(err instanceof Error ? err.message : "Sign in failed.")
+      setIsLoading(false)
+    }
+  }
 
   const handleGoogleLogin = async () => {
     setManualError(null)
@@ -80,6 +101,41 @@ const LoginPageClient = () => {
             )}
             {isLoading ? "Redirecting to Google…" : "Continue with Google"}
           </button>
+
+          {IS_LOCAL_SUPABASE && (
+            <>
+              <div className="my-4 flex items-center gap-3">
+                <hr className="flex-1 border-slate-200" />
+                <span className="text-xs text-slate-400">local dev only</span>
+                <hr className="flex-1 border-slate-200" />
+              </div>
+              <form onSubmit={handleDevLogin} className="flex flex-col gap-3">
+                <input
+                  type="email"
+                  placeholder="Email"
+                  value={devEmail}
+                  onChange={e => setDevEmail(e.target.value)}
+                  required
+                  className="rounded-xl border border-slate-200 px-4 py-3 text-sm text-slate-700 outline-none focus:border-slate-400"
+                />
+                <input
+                  type="password"
+                  placeholder="Password"
+                  value={devPassword}
+                  onChange={e => setDevPassword(e.target.value)}
+                  required
+                  className="rounded-xl border border-slate-200 px-4 py-3 text-sm text-slate-700 outline-none focus:border-slate-400"
+                />
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className="rounded-xl bg-slate-800 py-3 text-sm font-semibold text-white hover:bg-slate-700 transition-colors disabled:opacity-50"
+                >
+                  Sign in with email
+                </button>
+              </form>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -39,6 +39,7 @@ export default function BookmarksPage() {
   const [bulkSubmitting, setBulkSubmitting] = useState(false)
   const [removeTarget, setRemoveTarget] = useState<BookmarkedClinic | null>(null)
   const [consultTarget, setConsultTarget] = useState<BookmarkedClinic | null>(null)
+  const [emailWarning, setEmailWarning] = useState(false)
 
   // Redirect unauthenticated users
   useEffect(() => {
@@ -88,38 +89,44 @@ export default function BookmarksPage() {
     if (!consultTarget) return
     const clinic = consultTarget
     setConsultTarget(null)
-    setClinics((prev) =>
-      prev.map((c) => c.clinicId === clinic.clinicId ? { ...c, consultationRequested: true } : c)
-    )
     try {
-      await fetch("/api/consultations", {
+      const res = await fetch("/api/consultations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ clinicIds: [clinic.clinicId] }),
       })
+      if (!res.ok) throw new Error('request failed')
+      const data = await res.json()
+      setClinics((prev) =>
+        prev.map((c) => c.clinicId === clinic.clinicId ? { ...c, consultationRequested: true } : c)
+      )
+      if (!data.emailSent) setEmailWarning(true)
     } catch {
-      // non-fatal — optimistic update stands
+      // leave UI unchanged — clinic remains requestable
     }
   }
 
   const handleBulkRequest = async () => {
     setBulkSubmitting(true)
     const ids = Array.from(selected)
-    setClinics((prev) =>
-      prev.map((c) => ids.includes(c.clinicId) ? { ...c, consultationRequested: true } : c)
-    )
     try {
-      await fetch("/api/consultations", {
+      const res = await fetch("/api/consultations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ clinicIds: ids }),
       })
-    } catch {
-      // non-fatal
-    } finally {
-      setBulkSubmitting(false)
+      if (!res.ok) throw new Error('request failed')
+      const data = await res.json()
+      setClinics((prev) =>
+        prev.map((c) => ids.includes(c.clinicId) ? { ...c, consultationRequested: true } : c)
+      )
+      if (!data.emailSent) setEmailWarning(true)
       setSelected(new Set())
       setBulkModalOpen(false)
+    } catch {
+      // leave UI unchanged — user can retry
+    } finally {
+      setBulkSubmitting(false)
     }
   }
 
@@ -153,6 +160,11 @@ export default function BookmarksPage() {
 
   return (
     <Container className="py-12">
+      {emailWarning && (
+        <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          Your consultation request was saved, but we had trouble sending the notification. Our team will be in touch within 24 hours.
+        </div>
+      )}
       <div className="mb-8 flex items-center justify-between gap-4">
         <div>
           <h1 className={cn(merriweather.className, "text-3xl font-bold text-[#0D1E32]")}>

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { MapPin, Star, Bookmark, Check } from "lucide-react"
+import { Merriweather } from "next/font/google"
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useBookmarkCount } from "@/contexts/BookmarkCountContext"
+import { Button } from "@/components/ui/button"
+import Container from "@/components/ui/container"
+import { cn } from "@/lib/utils"
+import { ConsultationConfirmModal } from "@/components/istanbulmedic-connect/ConsultationConfirmModal"
+
+const merriweather = Merriweather({ subsets: ["latin"], weight: ["700"] })
+
+interface BookmarkedClinic {
+  bookmarkId: string
+  clinicId: string
+  name: string
+  location: string
+  image: string | null
+  rating: number | null
+  reviewCount: number
+  consultationRequested: boolean
+}
+
+export default function BookmarksPage() {
+  const { isAuthenticated, loading: authLoading } = useAuth()
+  const { removeId } = useBookmarkCount()
+  const router = useRouter()
+
+  const [clinics, setClinics] = useState<BookmarkedClinic[]>([])
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [bulkModalOpen, setBulkModalOpen] = useState(false)
+  const [bulkSubmitting, setBulkSubmitting] = useState(false)
+  const [removeTarget, setRemoveTarget] = useState<BookmarkedClinic | null>(null)
+  const [consultTarget, setConsultTarget] = useState<BookmarkedClinic | null>(null)
+
+  // Redirect unauthenticated users
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      document.cookie = `auth_redirect_next=${encodeURIComponent("/bookmarks")}; path=/; max-age=300`
+      router.push("/auth/login")
+    }
+  }, [authLoading, isAuthenticated, router])
+
+  const fetchBookmarks = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/bookmarks")
+      if (!res.ok) return
+      const data = await res.json()
+      setClinics(data.bookmarks ?? [])
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isAuthenticated) fetchBookmarks()
+  }, [isAuthenticated, fetchBookmarks])
+
+  const handleRemove = async () => {
+    if (!removeTarget) return
+    const { clinicId } = removeTarget
+    setClinics((prev) => prev.filter((c) => c.clinicId !== clinicId))
+    setSelected((prev) => { const s = new Set(prev); s.delete(clinicId); return s })
+    removeId(clinicId)
+    setRemoveTarget(null)
+    try {
+      await fetch("/api/bookmarks", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicId }),
+      })
+    } catch {
+      fetchBookmarks() // revert page list on error (context will re-sync on next auth change)
+    }
+  }
+
+  const handleRequestOne = async () => {
+    if (!consultTarget) return
+    const clinic = consultTarget
+    setConsultTarget(null)
+    setClinics((prev) =>
+      prev.map((c) => c.clinicId === clinic.clinicId ? { ...c, consultationRequested: true } : c)
+    )
+    try {
+      await fetch("/api/consultations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicIds: [clinic.clinicId] }),
+      })
+    } catch {
+      // non-fatal — optimistic update stands
+    }
+  }
+
+  const handleBulkRequest = async () => {
+    setBulkSubmitting(true)
+    const ids = Array.from(selected)
+    setClinics((prev) =>
+      prev.map((c) => ids.includes(c.clinicId) ? { ...c, consultationRequested: true } : c)
+    )
+    try {
+      await fetch("/api/consultations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicIds: ids }),
+      })
+    } catch {
+      // non-fatal
+    } finally {
+      setBulkSubmitting(false)
+      setSelected(new Set())
+      setBulkModalOpen(false)
+    }
+  }
+
+  const toggleSelect = (clinicId: string) => {
+    setSelected((prev) => {
+      const s = new Set(prev)
+      if (s.has(clinicId)) s.delete(clinicId)
+      else s.add(clinicId)
+      return s
+    })
+  }
+
+  const selectableIds = clinics.filter((c) => !c.consultationRequested).map((c) => c.clinicId)
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id))
+  const toggleAll = () => {
+    if (allSelected) setSelected(new Set())
+    else setSelected(new Set(selectableIds))
+  }
+
+  if (authLoading || loading) {
+    return (
+      <Container className="py-20">
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 rounded-2xl bg-slate-100 animate-pulse" />
+          ))}
+        </div>
+      </Container>
+    )
+  }
+
+  return (
+    <Container className="py-12">
+      <div className="mb-8 flex items-center justify-between gap-4">
+        <div>
+          <h1 className={cn(merriweather.className, "text-3xl font-bold text-[#0D1E32]")}>
+            Saved Clinics
+          </h1>
+          <p className="mt-2 text-sm text-slate-500">
+            {clinics.length === 0
+              ? "You haven't saved any clinics yet."
+              : `${clinics.length} saved clinic${clinics.length !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+        {selected.size > 0 && (
+          <Button
+            variant="teal-primary"
+            onClick={() => setBulkModalOpen(true)}
+            disabled={bulkSubmitting}
+            className="shrink-0"
+          >
+            Request Consultation ({selected.size})
+          </Button>
+        )}
+      </div>
+
+      {clinics.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 py-20 text-center">
+          <Bookmark className="mx-auto mb-4 h-10 w-10 text-slate-300" />
+          <p className="text-sm font-medium text-slate-500">No saved clinics yet</p>
+          <p className="mt-1 text-xs text-slate-400">
+            Bookmark clinics while browsing to save them here.
+          </p>
+          <Link
+            href="/clinics"
+            className="mt-5 inline-block text-sm font-semibold text-[#3EBBB7] hover:underline"
+          >
+            Browse clinics
+          </Link>
+        </div>
+      ) : (
+        <>
+          {selectableIds.length > 1 && (
+            <div className="mb-4 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={toggleAll}
+                className="text-xs font-medium text-[#3EBBB7] hover:underline"
+              >
+                {allSelected ? "Deselect all" : "Select all"}
+              </button>
+              {selected.size > 0 && (
+                <span className="text-xs text-slate-400">
+                  {selected.size} selected
+                </span>
+              )}
+            </div>
+          )}
+
+          <ul className="space-y-3">
+            {clinics.map((clinic) => (
+              <li
+                key={clinic.clinicId}
+                className="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+              >
+                {/* Select checkbox (only for unrequested) */}
+                {!clinic.consultationRequested && (
+                  <input
+                    type="checkbox"
+                    checked={selected.has(clinic.clinicId)}
+                    onChange={() => toggleSelect(clinic.clinicId)}
+                    className="h-4 w-4 shrink-0 rounded border-slate-300 accent-[#3EBBB7]"
+                    aria-label={`Select ${clinic.name}`}
+                  />
+                )}
+
+                {/* Clinic image */}
+                <Link href={`/clinics/${clinic.clinicId}`} className="relative h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                  {clinic.image ? (
+                    <Image src={clinic.image} alt={clinic.name} fill sizes="56px" className="object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-[10px] text-slate-300">
+                      No img
+                    </div>
+                  )}
+                </Link>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <Link href={`/clinics/${clinic.clinicId}`} className="font-semibold text-[#0D1E32] hover:text-[#3EBBB7] transition-colors truncate block">
+                    {clinic.name}
+                  </Link>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                    <span className="flex items-center gap-1 text-xs text-slate-400">
+                      <MapPin className="h-3 w-3 shrink-0" />
+                      {clinic.location}
+                    </span>
+                    {clinic.rating != null && (
+                      <span className="flex items-center gap-1 text-xs text-slate-400">
+                        <Star className="h-3 w-3 fill-current text-[#FFD700]" />
+                        {clinic.rating.toFixed(1)}
+                        {clinic.reviewCount > 0 && (
+                          <span className="text-slate-400/70">({clinic.reviewCount.toLocaleString()})</span>
+                        )}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex shrink-0 items-center gap-3">
+                  {clinic.consultationRequested ? (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Check className="h-3.5 w-3.5 text-[#3EBBB7]" />
+                      Requested
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setConsultTarget(clinic)}
+                      className="text-xs font-medium text-[#3EBBB7] hover:underline underline-offset-2"
+                    >
+                      Request Consultation
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(clinic)}
+                    aria-label={`Remove ${clinic.name} from bookmarks`}
+                    className="text-slate-300 hover:text-red-400 transition-colors"
+                  >
+                    <Bookmark className="h-4 w-4 fill-current" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* Individual consultation request modal */}
+      <ConsultationConfirmModal
+        open={consultTarget !== null}
+        onOpenChange={(open) => !open && setConsultTarget(null)}
+        clinicName={consultTarget?.name ?? ""}
+        isRemoving={false}
+        onConfirm={handleRequestOne}
+      />
+
+      {/* Remove bookmark modal */}
+      <ConsultationConfirmModal
+        open={removeTarget !== null}
+        onOpenChange={(open) => !open && setRemoveTarget(null)}
+        clinicName={removeTarget?.name ?? ""}
+        isRemoving={true}
+        onConfirm={handleRemove}
+      />
+
+      {/* Bulk request modal */}
+      <ConsultationConfirmModal
+        open={bulkModalOpen}
+        onOpenChange={(open) => !open && setBulkModalOpen(false)}
+        clinicName={`${selected.size} clinic${selected.size !== 1 ? "s" : ""}`}
+        isRemoving={false}
+        onConfirm={handleBulkRequest}
+      />
+    </Container>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { Dancing_Script, Geist, Geist_Mono, Merriweather, Poppins } from "next/font/google"
 import "./globals.css"
 import { AuthProvider } from "@/contexts/AuthContext"
+import { BookmarkCountProvider } from "@/contexts/BookmarkCountContext"
 import { LanguageProvider } from "@/contexts/LanguageContext"
 import { TopNav } from "@/components/istanbulmedic-connect/TopNav"
 import Footer from "@/components/common/Footer"
@@ -54,6 +55,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         <AuthProvider>
+          <BookmarkCountProvider>
           <LanguageProvider>
             <TopNav />
             <div className="flex min-h-screen flex-col pt-[80px]">
@@ -61,6 +63,7 @@ export default function RootLayout({
               <Footer />
             </div>
           </LanguageProvider>
+          </BookmarkCountProvider>
         </AuthProvider>
       </body>
     </html>

--- a/components/istanbulmedic-connect/BookmarkButton.tsx
+++ b/components/istanbulmedic-connect/BookmarkButton.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useState } from "react"
+import { Bookmark } from "lucide-react"
+import { useRouter } from "next/navigation"
+
+import { useAuth } from "@/contexts/AuthContext"
+import { useBookmarkCount } from "@/contexts/BookmarkCountContext"
+import { cn } from "@/lib/utils"
+
+interface BookmarkButtonProps {
+  clinicId: string
+  clinicName: string
+  className?: string
+  iconClassName?: string
+  /** Optional text label shown next to the icon */
+  label?: string
+  /** Label shown when already bookmarked — defaults to label */
+  labelSaved?: string
+}
+
+export function BookmarkButton({
+  clinicId,
+  clinicName,
+  className,
+  iconClassName,
+  label,
+  labelSaved,
+}: BookmarkButtonProps) {
+  const { bookmarkedIds, addId, removeId } = useBookmarkCount()
+  const bookmarked = bookmarkedIds.has(clinicId)
+  const [loading, setLoading] = useState(false)
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!isAuthenticated) {
+      document.cookie = `auth_redirect_next=${encodeURIComponent(window.location.pathname)}; path=/; max-age=300`
+      router.push("/auth/login")
+      return
+    }
+    if (bookmarked) {
+      handleRemove()
+    } else {
+      handleAdd()
+    }
+  }
+
+  const handleAdd = async () => {
+    setLoading(true)
+    addId(clinicId)
+    try {
+      const res = await fetch("/api/bookmarks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicId }),
+      })
+      if (!res.ok) removeId(clinicId)
+    } catch {
+      removeId(clinicId)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setLoading(true)
+    removeId(clinicId)
+    try {
+      const res = await fetch("/api/bookmarks", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicId }),
+      })
+      if (!res.ok) addId(clinicId)
+    } catch {
+      addId(clinicId)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const displayLabel = bookmarked ? (labelSaved ?? label) : label
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={loading}
+      aria-label={bookmarked ? `Remove ${clinicName} from bookmarks` : `Bookmark ${clinicName}`}
+      className={cn(
+        "transition-colors duration-200 disabled:opacity-50",
+        bookmarked
+          ? "text-[#3EBBB7] hover:text-red-400"
+          : "text-muted-foreground hover:text-[#3EBBB7]",
+        className
+      )}
+    >
+      <Bookmark className={cn("h-4 w-4", bookmarked && "fill-current", iconClassName)} />
+      {displayLabel && <span>{displayLabel}</span>}
+    </button>
+  )
+}

--- a/components/istanbulmedic-connect/ClinicCard.tsx
+++ b/components/istanbulmedic-connect/ClinicCard.tsx
@@ -2,9 +2,8 @@
 
 import Image from "next/image"
 import { useId, useState } from "react"
-import { MapPin, Star } from "lucide-react"
+import { MapPin, Star, Check } from "lucide-react"
 import { Merriweather } from "next/font/google"
-
 
 import { Checkbox } from "@/components/ui/checkbox"
 import { Card, CardContent } from "@/components/ui/card"
@@ -14,6 +13,10 @@ import {
 } from "@/components/ui/specialty-tag"
 import { cn } from "@/lib/utils"
 import { FEATURE_CONFIG } from "@/lib/filterConfig"
+import { useAuth } from "@/contexts/AuthContext"
+import { useRouter } from "next/navigation"
+import { ConsultationConfirmModal } from "@/components/istanbulmedic-connect/ConsultationConfirmModal"
+import { BookmarkButton } from "@/components/istanbulmedic-connect/BookmarkButton"
 
 const merriweather = Merriweather({
   subsets: ["latin"],
@@ -21,6 +24,7 @@ const merriweather = Merriweather({
 })
 
 interface ClinicCardProps {
+  id: string
   name: string
   location: string
   image: string | null
@@ -34,6 +38,7 @@ interface ClinicCardProps {
 }
 
 export const ClinicCard = ({
+  id,
   name,
   location,
   image,
@@ -46,8 +51,38 @@ export const ClinicCard = ({
 }: ClinicCardProps) => {
   const compareId = useId()
   const [isCompared, setIsCompared] = useState(false)
+  const [consultationRequested, setConsultationRequested] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+
+  const handleConsultationClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!isAuthenticated) {
+      document.cookie = `auth_redirect_next=${encodeURIComponent(window.location.pathname)}; path=/; max-age=300`
+      router.push("/auth/login")
+      return
+    }
+    if (!consultationRequested) {
+      setModalOpen(true)
+    }
+  }
+
+  const handleConsultationConfirm = async () => {
+    try {
+      await fetch("/api/consultations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicIds: [id] }),
+      })
+    } catch {
+      // non-fatal — optimistic update already applied
+    }
+    setConsultationRequested(true)
+  }
 
   return (
+    <>
     <Card
       variant="interactive"
       radius="xl"
@@ -69,6 +104,20 @@ export const ClinicCard = ({
           ) : (
             <div className="flex h-full w-full items-center justify-center rounded-[16px] bg-muted/40 text-sm text-muted-foreground">
               No clinic photo uploaded
+            </div>
+          )}
+          {/* Bookmark icon — top-right overlay */}
+          {FEATURE_CONFIG.bookConsultation && (
+            <div
+              className="absolute top-2 right-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <BookmarkButton
+                clinicId={id}
+                clinicName={name}
+                className="grid h-8 w-8 place-items-center rounded-full bg-white/80 backdrop-blur-sm shadow-sm hover:bg-white"
+                iconClassName="h-4 w-4"
+              />
             </div>
           )}
         </div>
@@ -130,12 +179,12 @@ export const ClinicCard = ({
           )}
         </div>
 
-        {/* Right: Compare + View Profile */}
-        {FEATURE_CONFIG.compare && (
-          <div
-            className="flex shrink-0 flex-col items-end gap-2"
-            onClick={(e) => e.stopPropagation()}
-          >
+        {/* Right: Compare + Consultation text link */}
+        <div
+          className="flex shrink-0 flex-col items-end gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {FEATURE_CONFIG.compare && (
             <div className="flex items-center gap-2">
               <Checkbox
                 id={compareId}
@@ -150,10 +199,35 @@ export const ClinicCard = ({
                 Compare
               </label>
             </div>
-          </div>
-        )}
+          )}
+          {FEATURE_CONFIG.bookConsultation && (
+            consultationRequested ? (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Check className="h-3.5 w-3.5 text-[#3EBBB7]" />
+                Consultation Requested
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={handleConsultationClick}
+                className="text-xs font-medium text-[#3EBBB7] hover:underline underline-offset-2 transition-colors"
+              >
+                Request Free Consultation
+              </button>
+            )
+          )}
+        </div>
       </div>
       </CardContent>
     </Card>
+
+    <ConsultationConfirmModal
+      open={modalOpen}
+      onOpenChange={(open) => !open && setModalOpen(false)}
+      clinicName={name}
+      isRemoving={false}
+      onConfirm={handleConsultationConfirm}
+    />
+    </>
   )
 }

--- a/components/istanbulmedic-connect/ClinicCard.tsx
+++ b/components/istanbulmedic-connect/ClinicCard.tsx
@@ -70,15 +70,16 @@ export const ClinicCard = ({
 
   const handleConsultationConfirm = async () => {
     try {
-      await fetch("/api/consultations", {
+      const res = await fetch("/api/consultations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ clinicIds: [id] }),
       })
+      if (!res.ok) throw new Error('request failed')
+      setConsultationRequested(true)
     } catch {
-      // non-fatal — optimistic update already applied
+      // leave UI unchanged — user can retry
     }
-    setConsultationRequested(true)
   }
 
   return (

--- a/components/istanbulmedic-connect/ConsultationConfirmModal.tsx
+++ b/components/istanbulmedic-connect/ConsultationConfirmModal.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog"
+
+interface ConsultationConfirmModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  clinicName: string
+  isRemoving: boolean
+  onConfirm: () => void
+}
+
+export function ConsultationConfirmModal({
+  open,
+  onOpenChange,
+  clinicName,
+  isRemoving,
+  onConfirm,
+}: ConsultationConfirmModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader className="flex flex-row items-center justify-between space-y-0">
+          <DialogTitle>
+            {isRemoving ? "Remove Bookmark" : "Request Free Consultation"}
+          </DialogTitle>
+          <DialogClose className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+            <X className="h-4 w-4" aria-hidden />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        </DialogHeader>
+
+        <div className="text-sm text-muted-foreground pt-2 space-y-3">
+          {isRemoving ? (
+            <p>
+              Remove <span className="font-semibold text-foreground">{clinicName}</span> from your saved clinics?
+            </p>
+          ) : (
+            <>
+              <p>
+                Request a free consultation with <span className="font-semibold text-foreground">{clinicName}</span>?
+              </p>
+              <p>
+                The Istanbul Medic Connect team will be in touch.
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant={isRemoving ? "destructive" : "teal-primary"}
+            className="flex-1"
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+          >
+            {isRemoving ? "Remove" : "Request Consultation"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/istanbulmedic-connect/ExploreClinicsPage.tsx
+++ b/components/istanbulmedic-connect/ExploreClinicsPage.tsx
@@ -200,6 +200,7 @@ export const ExploreClinicsPage = ({
             clinics.map((clinic) => (
               <ClinicCard
                 key={clinic.id}
+                id={clinic.id}
                 name={clinic.name}
                 location={clinic.location}
                 image={clinic.image}

--- a/components/istanbulmedic-connect/TopNav.tsx
+++ b/components/istanbulmedic-connect/TopNav.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { LayoutDashboard, LogOut, Menu, User } from "lucide-react"
+import { Bookmark, LayoutDashboard, LogOut, Menu, User } from "lucide-react"
 import { AnimatePresence, motion } from "framer-motion"
 
 import Container from "@/components/ui/container"
@@ -11,6 +11,8 @@ import Logo from "@/components/common/Logo"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/contexts/AuthContext"
+import { useBookmarkCount } from "@/contexts/BookmarkCountContext"
+import { FEATURE_CONFIG } from "@/lib/filterConfig"
 
 const NAV_ITEMS = [
   { label: "Home", href: "/" },
@@ -32,6 +34,7 @@ export const TopNav = () => {
   const pathname = usePathname()
   const router = useRouter()
   const { isAuthenticated, loading: authLoading, logout } = useAuth()
+  const { count: bookmarkCount } = useBookmarkCount()
 
   const handleSignOut = async () => {
     setOpen(false)
@@ -171,6 +174,20 @@ export const TopNav = () => {
 
         {/* Desktop CTA - shrink-0 ensures both buttons stay visible */}
         <div className="hidden shrink-0 items-center gap-3 md:flex">
+          {FEATURE_CONFIG.bookConsultation && isAuthenticated && (
+            <Link
+              href="/bookmarks"
+              aria-label={`Saved clinics${bookmarkCount > 0 ? ` (${bookmarkCount})` : ""}`}
+              className="relative shrink-0 grid h-9 w-9 place-items-center rounded-full text-[#17375B] hover:bg-slate-100 transition-colors duration-200"
+            >
+              <Bookmark className="h-5 w-5" />
+              {bookmarkCount > 0 && (
+                <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[#3EBBB7] px-1 text-[10px] font-bold leading-none text-white">
+                  {bookmarkCount > 99 ? "99+" : bookmarkCount}
+                </span>
+              )}
+            </Link>
+          )}
           <Button
             variant="teal-primary"
             href={CONSULTATION_LINK}
@@ -306,6 +323,23 @@ export const TopNav = () => {
                         )
                       })}
 
+                      {FEATURE_CONFIG.bookConsultation && isAuthenticated && (
+                        <Link
+                          href="/bookmarks"
+                          onClick={() => setOpen(false)}
+                          className="flex items-center gap-3 rounded-2xl px-4 py-3 font-semibold text-[#0F2446] hover:text-[#0D1E32]"
+                        >
+                          <span className="relative">
+                            <Bookmark className="h-4 w-4 shrink-0" />
+                            {bookmarkCount > 0 && (
+                              <span className="absolute -top-1.5 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-[#3EBBB7] px-0.5 text-[9px] font-bold leading-none text-white">
+                                {bookmarkCount > 99 ? "99+" : bookmarkCount}
+                              </span>
+                            )}
+                          </span>
+                          <span>Saved Clinics</span>
+                        </Link>
+                      )}
                       <Button
                         variant="teal-primary"
                         href={CONSULTATION_LINK}

--- a/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
+++ b/components/istanbulmedic-connect/profile/ClinicProfilePage.tsx
@@ -318,8 +318,10 @@ export const ClinicProfilePage = ({ clinic, registryRecords, complianceHistory }
           {/* Sidebar */}
           <div className="lg:col-span-1">
             <SummarySidebar
-              transparencyScore={clinic.trustScore}
-              topSpecialties={specialties.slice(0, 3)}
+              clinicId={clinic.id}
+              clinicName={clinic.name}
+              clinicLocation={clinic.location}
+              clinicImageUrl={clinic.image}
               rating={clinic.rating ?? null}
               reviewCount={clinic.totalReviewCount}
               websiteUrl={clinic.websiteUrl}

--- a/components/istanbulmedic-connect/profile/SummarySidebar.tsx
+++ b/components/istanbulmedic-connect/profile/SummarySidebar.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useState } from "react"
-import { Plus, Bookmark, Share2, X, Globe} from "lucide-react"
+import { Plus, Share2, X, Globe, Check } from "lucide-react"
+import { useRouter } from "next/navigation"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -17,12 +18,19 @@ import { FeeLineItem } from "@/components/ui/fee-line-item"
 import { IconActionLink } from "@/components/ui/icon-action-link"
 import { PriceRatingBlock } from "@/components/ui/price-rating-block"
 import { VerificationBadge } from "@/components/ui/verification-badge"
-import { CONSULTATION_LINK } from "@/lib/constants"
 import { FEATURE_CONFIG } from "@/lib/filterConfig"
+import { useAuth } from "@/contexts/AuthContext"
+import { cn } from "@/lib/utils"
+import { ConsultationConfirmModal } from "@/components/istanbulmedic-connect/ConsultationConfirmModal"
+import { BookmarkButton } from "@/components/istanbulmedic-connect/BookmarkButton"
 
 interface SummarySidebarProps {
-  transparencyScore: number
-  topSpecialties: string[]
+  clinicId: string
+  clinicName: string
+  clinicLocation?: string
+  clinicImageUrl?: string | null
+  transparencyScore?: number
+  topSpecialties?: string[]
   rating: number | null
   reviewCount: number
   websiteUrl?: string | null
@@ -30,8 +38,6 @@ interface SummarySidebarProps {
   consultationFee?: string
   serviceCharge?: string
   totalEstimate?: string
-  bookConsultationHref?: string
-  onBookConsultation?: () => void
   onTalkToLeila?: () => void
   onAddToCompare?: () => void
   onSave?: () => void
@@ -39,8 +45,10 @@ interface SummarySidebarProps {
 }
 
 export const SummarySidebar = ({
-  transparencyScore,
-  topSpecialties,
+  clinicId,
+  clinicName,
+  clinicLocation = "",
+  clinicImageUrl,
   rating,
   reviewCount,
   websiteUrl,
@@ -48,14 +56,43 @@ export const SummarySidebar = ({
   consultationFee = "$0",
   serviceCharge = "$0",
   totalEstimate = "$1,200",
-  bookConsultationHref = CONSULTATION_LINK,
-  onBookConsultation,
   onTalkToLeila,
   onAddToCompare,
-  onSave,
   onShare,
 }: SummarySidebarProps) => {
   const [feeModalOpen, setFeeModalOpen] = useState<"consultation" | "service" | null>(null)
+  const [confirmModalOpen, setConfirmModalOpen] = useState(false)
+  const [consultationRequested, setConsultationRequested] = useState(false)
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+
+  // suppress unused-var warning — kept for future use
+  void clinicLocation
+  void clinicImageUrl
+
+  const handleConsultationClick = () => {
+    if (!isAuthenticated) {
+      document.cookie = `auth_redirect_next=${encodeURIComponent(window.location.pathname)}; path=/; max-age=300`
+      router.push("/auth/login")
+      return
+    }
+    if (!consultationRequested) {
+      setConfirmModalOpen(true)
+    }
+  }
+
+  const handleConsultationConfirm = async () => {
+    try {
+      await fetch("/api/consultations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clinicIds: [clinicId] }),
+      })
+    } catch {
+      // non-fatal
+    }
+    setConsultationRequested(true)
+  }
 
   return (
     <div className="sticky top-24">
@@ -72,17 +109,22 @@ export const SummarySidebar = ({
         <CardContent>
           <div className="grid gap-3">
             {FEATURE_CONFIG.bookConsultation && (
-              <Button
-                variant="teal-primary"
-                size="xl"
-                className="w-full font-medium"
-                href={bookConsultationHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={onBookConsultation}
-              >
-                Book Consultation
-              </Button>
+              consultationRequested ? (
+                <div className={cn(
+                  "flex w-full items-center justify-center gap-2 rounded-lg border border-slate-200 py-2.5 text-sm font-medium text-muted-foreground"
+                )}>
+                  <Check className="h-4 w-4 text-[#3EBBB7]" />
+                  Consultation Requested
+                </div>
+              ) : (
+                <Button
+                  variant="teal-primary"
+                  className="w-full"
+                  onClick={handleConsultationClick}
+                >
+                  Request Free Consultation
+                </Button>
+              )
             )}
 
             <Button
@@ -93,6 +135,17 @@ export const SummarySidebar = ({
             >
               Talk to Leila
             </Button>
+
+            {FEATURE_CONFIG.bookConsultation && (
+              <BookmarkButton
+                clinicId={clinicId}
+                clinicName={clinicName}
+                label="Save Clinic"
+                labelSaved="Saved"
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-slate-200 py-2.5 text-sm font-medium hover:border-[#3EBBB7]"
+                iconClassName="h-4 w-4"
+              />
+            )}
           </div>
 
           {FEATURE_CONFIG.profilePricing && (
@@ -128,11 +181,6 @@ export const SummarySidebar = ({
             Add to Compare
           </IconActionLink>
         )}
-        {FEATURE_CONFIG.saveClinic && (
-          <IconActionLink icon={<Bookmark className="h-4 w-4" />} onClick={onSave}>
-            Save Clinic
-          </IconActionLink>
-        )}
         {FEATURE_CONFIG.share && (
           <IconActionLink icon={<Share2 className="h-4 w-4" />} onClick={onShare}>
             Share
@@ -141,7 +189,7 @@ export const SummarySidebar = ({
         {websiteUrl && (
           <IconActionLink
             icon={<Globe className="h-4 w-4" />}
-            onClick={() => window.open(websiteUrl, '_blank', 'noopener,noreferrer')}
+            onClick={() => window.open(websiteUrl, "_blank", "noopener,noreferrer")}
           >
             Visit Website
           </IconActionLink>
@@ -186,6 +234,14 @@ export const SummarySidebar = ({
           </div>
         </DialogContent>
       </Dialog>
+
+      <ConsultationConfirmModal
+        open={confirmModalOpen}
+        onOpenChange={(open) => !open && setConfirmModalOpen(false)}
+        clinicName={clinicName}
+        isRemoving={false}
+        onConfirm={handleConsultationConfirm}
+      />
     </div>
   )
 }

--- a/components/istanbulmedic-connect/profile/SummarySidebar.tsx
+++ b/components/istanbulmedic-connect/profile/SummarySidebar.tsx
@@ -83,15 +83,16 @@ export const SummarySidebar = ({
 
   const handleConsultationConfirm = async () => {
     try {
-      await fetch("/api/consultations", {
+      const res = await fetch("/api/consultations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ clinicIds: [clinicId] }),
       })
+      if (!res.ok) throw new Error('request failed')
+      setConsultationRequested(true)
     } catch {
-      // non-fatal
+      // leave UI unchanged — user can retry
     }
-    setConsultationRequested(true)
   }
 
   return (

--- a/components/istanbulmedic-connect/user-profile/sections/ProfileConsultations.tsx
+++ b/components/istanbulmedic-connect/user-profile/sections/ProfileConsultations.tsx
@@ -1,51 +1,156 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { MapPin, Clock } from 'lucide-react'
+import { Merriweather } from 'next/font/google'
+import { cn } from '@/lib/utils'
+
+const merriweather = Merriweather({ subsets: ['latin'], weight: ['700'] })
+
+interface Consultation {
+  id: string
+  status: string
+  createdAt: string
+  clinicId: string | null
+  clinicName: string
+  clinicLocation: string
+  clinicImage: string | null
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-600 border border-amber-200">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  )
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
 export default function ProfileConsultations() {
+  const [consultations, setConsultations] = useState<Consultation[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/consultations')
+      .then((r) => r.json())
+      .then((data) => setConsultations(data.consultations ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[#0D1E32]">Consultations</h1>
-        <p className="text-slate-500 text-sm mt-1">Book and manage consultations with clinics</p>
+        <h1 className={cn(merriweather.className, 'text-2xl font-bold text-[#0D1E32]')}>
+          Consultations
+        </h1>
+        <p className="text-slate-500 text-sm mt-1">
+          Your consultation requests with clinics
+        </p>
       </div>
 
-      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-12 text-center">
-        <div className="w-16 h-16 rounded-2xl bg-[#3EBBB7]/10 flex items-center justify-center mx-auto mb-5">
-          <svg
-            className="w-8 h-8 text-[#3EBBB7]"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 01-.825-.242m9.345-8.334a2.126 2.126 0 00-.476-.095 48.64 48.64 0 00-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0011.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155" />
-          </svg>
-        </div>
-
-        <span className="inline-block px-3 py-1 rounded-full bg-[#3EBBB7]/10 text-[#3EBBB7] text-xs font-semibold mb-4">
-          Coming soon
-        </span>
-
-        <h2 className="text-lg font-semibold text-[#0D1E32] mb-2">Consultations are on the way</h2>
-        <p className="text-slate-500 text-sm max-w-md mx-auto">
-          Soon you&apos;ll be able to shortlist clinics, schedule consultations directly through the platform, and manage all your bookings in one place.
-        </p>
-
-        <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-lg mx-auto">
-          {[
-            { label: 'Clinic shortlisting', icon: '🏥' },
-            { label: 'Schedule consultations', icon: '📅' },
-            { label: 'Manage bookings', icon: '✅' },
-          ].map((item) => (
-            <div
-              key={item.label}
-              className="flex flex-col items-center gap-2 p-4 rounded-xl bg-slate-50 border border-slate-100"
-            >
-              <span className="text-2xl">{item.icon}</span>
-              <p className="text-xs font-medium text-slate-600 text-center">{item.label}</p>
-            </div>
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 rounded-2xl bg-slate-100 animate-pulse" />
           ))}
         </div>
-      </div>
+      ) : consultations.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 py-16 text-center">
+          <Clock className="mx-auto mb-4 h-10 w-10 text-slate-300" />
+          <p className="text-sm font-medium text-slate-500">No consultations yet</p>
+          <p className="mt-1 text-xs text-slate-400">
+            Request a free consultation from any clinic page or your saved clinics.
+          </p>
+          <div className="mt-5 flex justify-center gap-4">
+            <Link href="/clinics" className="text-sm font-semibold text-[#3EBBB7] hover:underline">
+              Browse clinics
+            </Link>
+            <Link href="/bookmarks" className="text-sm font-semibold text-[#3EBBB7] hover:underline">
+              Saved clinics
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50">
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Clinic
+                </th>
+                <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 sm:table-cell">
+                  Date Submitted
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {consultations.map((c) => (
+                <tr key={c.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                        {c.clinicImage ? (
+                          <Image
+                            src={c.clinicImage}
+                            alt={c.clinicName}
+                            fill
+                            sizes="40px"
+                            className="object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-[10px] text-slate-300">
+                            No img
+                          </div>
+                        )}
+                      </div>
+                      <div className="min-w-0">
+                        {c.clinicId ? (
+                          <Link
+                            href={`/clinics/${c.clinicId}`}
+                            className="font-semibold text-[#0D1E32] hover:text-[#3EBBB7] transition-colors truncate block"
+                          >
+                            {c.clinicName}
+                          </Link>
+                        ) : (
+                          <span className="font-semibold text-[#0D1E32] truncate block">
+                            {c.clinicName}
+                          </span>
+                        )}
+                        {c.clinicLocation && (
+                          <span className="flex items-center gap-1 text-xs text-slate-400 mt-0.5">
+                            <MapPin className="h-3 w-3 shrink-0" />
+                            {c.clinicLocation}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="hidden px-4 py-3 text-slate-500 sm:table-cell">
+                    {formatDate(c.createdAt)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={c.status} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/contexts/BookmarkCountContext.tsx
+++ b/contexts/BookmarkCountContext.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react"
+import { useAuth } from "@/contexts/AuthContext"
+
+interface BookmarkCountContextValue {
+  count: number
+  bookmarkedIds: Set<string>
+  addId: (clinicId: string) => void
+  removeId: (clinicId: string) => void
+}
+
+const BookmarkCountContext = createContext<BookmarkCountContextValue>({
+  count: 0,
+  bookmarkedIds: new Set(),
+  addId: () => {},
+  removeId: () => {},
+})
+
+export function BookmarkCountProvider({ children }: { children: React.ReactNode }) {
+  const [bookmarkedIds, setBookmarkedIds] = useState<Set<string>>(new Set())
+  const { isAuthenticated } = useAuth()
+
+  // Re-fetch the full bookmark list whenever auth state changes.
+  // On logout this clears the set; on login it populates it.
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setBookmarkedIds(new Set())
+      return
+    }
+    fetch("/api/bookmarks")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.bookmarks) {
+          setBookmarkedIds(new Set(data.bookmarks.map((b: { clinicId: string }) => b.clinicId)))
+        }
+      })
+      .catch(() => {})
+  }, [isAuthenticated])
+
+  const addId = useCallback((clinicId: string) => {
+    setBookmarkedIds((prev) => new Set(prev).add(clinicId))
+  }, [])
+
+  const removeId = useCallback((clinicId: string) => {
+    setBookmarkedIds((prev) => {
+      const next = new Set(prev)
+      next.delete(clinicId)
+      return next
+    })
+  }, [])
+
+  return (
+    <BookmarkCountContext.Provider
+      value={{ count: bookmarkedIds.size, bookmarkedIds, addId, removeId }}
+    >
+      {children}
+    </BookmarkCountContext.Provider>
+  )
+}
+
+export const useBookmarkCount = () => useContext(BookmarkCountContext)

--- a/contexts/BookmarkCountContext.tsx
+++ b/contexts/BookmarkCountContext.tsx
@@ -25,6 +25,7 @@ export function BookmarkCountProvider({ children }: { children: React.ReactNode 
   // On logout this clears the set; on login it populates it.
   useEffect(() => {
     if (!isAuthenticated) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setBookmarkedIds(new Set())
       return
     }

--- a/docs/architecture/clinic-scoring-architecture.md
+++ b/docs/architecture/clinic-scoring-architecture.md
@@ -1,0 +1,658 @@
+# Clinic Scoring Architecture
+
+## Overview
+
+This document captures the current scoring architecture direction for clinic ranking and trust presentation.
+
+The model uses:
+
+- 2 public-facing pillars
+- a final overall clinic score
+- a small set of public source summaries
+- direct pillar inputs for thinner or more sensitive data sources
+
+## Core Principles
+
+- Pillars should be meaningful dimensions, not thin buckets with only 1-2 weak signals.
+- Source summaries are secondary, not the primary scoring primitive.
+- Metrics map to pillars. Sources do not map to pillars 1:1.
+- Public source summaries should only exist for sources with strong, interpretable signal.
+- Sensitive or sparse data such as doctor credentials should inform pillar scoring without becoming a public scorecard.
+- Both pillar scores and source summaries should derive from the same underlying normalized metrics to avoid incoherent discrepancies.
+
+## Final Public Model
+
+### Pillars
+
+- `Reputation`
+- `Evidence & Transparency`
+
+### Final Score
+
+- `overall_score`
+
+### Public Secondary Source Summaries
+
+- `Google`
+- `Reddit`
+- `HRN`
+
+### Inputs That Should Not Be Public Source Summaries
+
+- Website / disclosure signals
+- Registry / verification signals
+- Credentials / certifications / memberships
+- Doctor table data when it exists
+- Instagram / social presence
+
+These should feed the pillar scores directly rather than become standalone public scorecards.
+
+## Why This Model
+
+### Why not keep Transparency separate?
+
+Standalone `Transparency` looked too thin. In practice it blended two related ideas:
+
+- how much the clinic discloses itself
+- how much accessible and verifiable information exists across the web
+
+Those fit better together as `Evidence & Transparency`.
+
+### Why not keep Clinical Governance separate?
+
+Standalone `Clinical Governance` also looked too thin for a major public pillar. The available signals are important, but currently limited:
+
+- registry presence
+- license / verifiable status
+- certifications / accreditations / memberships
+
+These fit more naturally inside `Evidence & Transparency` as verifiable trust-supporting evidence.
+
+### Why not make doctor credentials public-facing?
+
+- the data may be too sparse to support a robust public summary
+- it risks being interpreted as a public rating of individual doctors
+- it is better used as an internal trust input than a headline scorecard
+
+## Architecture Diagram
+
+```text
+                    FINAL CLINIC SCORING ARCHITECTURE (2-PILLAR MODEL)
+
+
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ 1. INPUT DATA                                                               │
+│                                                                              │
+│  clinic_scraped_data         -> website/public disclosure signals            │
+│  clinic_google_places        -> google review signals                        │
+│  clinic_forum_profiles       -> forum aggregate signals                      │
+│  forum_thread_llm_analysis   -> forum sentiment / issue / repair signals     │
+│  clinic_social_media         -> social presence                              │
+│  clinic_instagram_posts      -> instagram engagement/activity                │
+│  clinic_credentials          -> certifications / memberships                 │
+│  clinic_team / doctor table  -> doctor/team/credential context               │
+│  registry data               -> listed / licensed / verifiable status        │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ 2. SOURCE-SPECIFIC METRICS                                                  │
+│                                                                              │
+│                                                                              │
+│  GOOGLE                                                                     │
+│  - rating                                                                   │
+│  - review count                                                             │
+│                                                                              │
+│  REDDIT                                                                     │
+│  - sentiment                                                                │
+│  - thread count                                                             │
+│  - unique authors                                                           │
+│  - long-term evidence                                                       │
+│  - repair/caution signals                                                   │
+│                                                                              │
+│  HRN                                                                        │
+│  - sentiment                                                                │
+│  - photo threads                                                            │
+│  - 12m+ followups                                                           │
+│  - thread count                                                             │
+│  - repair/caution signals                                                   │
+│                                                                              │
+│  INSTAGRAM                                                                  │
+│  - account exists                                                           │
+│  - engagement                                                               │
+│  - posting activity - maybe just slight                                     |
+|                          reward                                             │
+│                                                                              │
+│  GOVERNANCE / VERIFICATION                                                  │
+│  - registry listed                                                          │
+│  - license/verifiable status                                                │
+│  - certifications/accreditations/memberships                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                 ┌────────────────────┴────────────────────┐
+                 ▼                                         ▼
+
+┌──────────────────────────────────────────────────┐   ┌───────────────────────┐
+│ 3A. PILLAR CONTRIBUTION MAPPING                  │   │ 3B. SOURCE SUMMARIES   │
+│                                                  │   │   public secondary     │
+│ Reputation                                       │   │                       │
+│ <- google rating                                 │   │ Google summary        │
+│ <- google review signal                          │   │ Reddit summary        │
+│ <- reddit sentiment                              │   │ HRN summary           │
+│ <- reddit repair/caution signals                 │   │                       │
+│ <- hrn sentiment                                 │   │ No standalone public  │
+│ <- hrn repair/caution signals                    │   │ source score for:     │
+│ <- light social contribution if ever needed      │   │ - Website             │
+|    (instagram metrics)
+│                                                  │   │ - Registry            │
+│ Evidence & Transparency                          │   │ - Credentials         │
+│                                                  │   │ - Doctor data         │
+│ <- reddit thread volume / unique voices          │   │ - Instagram           │
+│ <- reddit long-term evidence                     │   └───────────────────────┘
+│ <- hrn photo threads / 12m+ followups            │
+│ <- hrn thread volume                             │
+│ <- google review volume                          │
+│ <- source breadth                                │
+│ <- registry/verifiable presence                  │
+│ <- credentials/accreditations/memberships        │
+│ <- doctor/team disclosure or verification        │
+└──────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ 4. PILLAR SCORES                                                            │
+│                                                                              │
+│  reputation_score                                                           │
+│  evidence_transparency_score                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ 5. FINAL CLINIC SCORE                                                       │
+│                                                                              │
+│  overall_score = weighted blend of:                                         │
+│  - reputation_score                                                         │
+│  - evidence_transparency_score                                              │
+│                                                                              │
+│  output:                                                                    │
+│  - overall score                                                            │
+│  - score band                                                               │
+│  - clinic ranking                                                           │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Pillar Definitions
+
+### Reputation
+
+`Reputation` represents what external public signals say about the clinic.
+
+Example inputs:
+
+- Google rating
+- Google review signal
+- Reddit sentiment
+- HRN sentiment
+- Reddit repair / caution signals
+- HRN repair / caution signals
+- very light social contribution if justified later
+
+This pillar should reflect sentiment and cautionary external signals, not disclosure quality or formal verification.
+
+### Evidence & Transparency
+
+`Evidence & Transparency` represents how much trustworthy, accessible, and disclosed information exists about the clinic.
+
+Example inputs:
+
+- pricing clarity
+- package clarity
+- doctor/team info listed
+- before/after presence
+- reddit thread volume
+- reddit unique voices
+- reddit long-term evidence
+- HRN photo threads
+- HRN 12+ month followups
+- HRN thread volume
+- Google review volume
+- source breadth
+- registry / verifiable presence
+- credentials / accreditations / memberships
+- doctor/team verification context
+
+This pillar intentionally combines:
+
+- self-disclosure by the clinic
+- independent volume of evidence
+- verifiable supporting trust signals
+
+## Source Summary Rules
+
+### Public Source Summaries
+
+Only use public source summaries where the source has enough substance and the summary is easy to interpret.
+
+Current candidates:
+
+- `Google`
+- `Reddit`
+- `HRN`
+
+### Non-Public Inputs
+
+These should stay as pillar inputs rather than public scorecards:
+
+- Website
+- Registry
+- Credentials
+- Doctor table data
+- Instagram
+
+Reasons:
+
+- too thin to justify a standalone public summary
+- too noisy relative to trust value
+- too sensitive or ethically awkward for public scoring
+
+## How Source Summaries Should Be Calculated
+
+Source summaries should be calculated from the same normalized source-specific metrics used by pillar scoring.
+
+Pattern:
+
+```text
+raw source data
+  -> source-specific metrics
+  -> normalized subscores
+  -> source summary score
+
+same source-specific metrics
+  -> pillar contribution mapping
+  -> pillar scores
+```
+
+This shared-metrics architecture reduces the risk of obvious contradictions between high source summaries and low overall scores.
+
+## Coherence Rules
+
+To keep the scoring system understandable:
+
+- Strong source metrics should usually create strong contribution to at least one pillar.
+- Weak source metrics should not quietly drive a high overall score.
+- Important metrics should remain important across both source summaries and pillar logic, even if exact weights differ.
+- No major hidden penalties should exist without a visible explanation.
+- Users should be able to look at source signals and understand why the pillar scores landed where they did.
+
+## Practical Product Guidance
+
+### Primary Public Display
+
+Show:
+
+- `Reputation`
+- `Evidence & Transparency`
+- `Overall Score`
+
+### Secondary Public Display
+
+Optionally show:
+
+- `Google`
+- `Reddit`
+- `HRN`
+
+These should read as supporting evidence layers, not as competing headline scores.
+
+### Internal / Future-Facing Inputs
+
+Keep these in the model as direct inputs even if they do not become public scorecards:
+
+- website disclosure data from `clinic_scraped_data`
+- registry verification data
+- `clinic_credentials`
+- `clinic_team` and any future doctor-normalized table
+- light social/Instagram signals if they prove useful
+
+## Open Implementation Notes
+
+- `clinic_scraped_data` is assumed to exist as an upstream scrape/enrichment table.
+- A future doctor-normalized table can be added to the input layer without changing the public scoring model.
+- If Instagram later becomes much richer and more interpretable, it can be reconsidered, but it should not be forced into a public source summary now.
+- The repo already has `clinic_scores` and `clinic_score_components`; these may be extendable for final storage, though source-level and pillar-level persistence may still need dedicated tables or JSON breakdowns.
+
+## Reputation Pillar v1.5
+
+This section captures the current proposed v1.5 implementation for the `Reputation` pillar.
+
+### Top-Level Reputation Formula
+
+```text
+Reputation =
+  0.35 * google_rating_score
++ 0.15 * google_review_signal
++ 0.20 * reddit_sentiment_score
+- 0.10 * reddit_caution_penalty
++ 0.20 * hrn_sentiment_score
+- 0.10 * hrn_caution_penalty
++ instagram_boost
+```
+
+Rules:
+
+- all weighted inputs except Instagram should be normalized to `0-100`
+- `Reputation` should be clamped to `0-100`
+- `instagram_boost` should be small and capped
+- Instagram should never function as a major reputation driver
+
+### Why This Version
+
+- it uses only the metrics already defined under `Reputation` in the architecture diagram
+- it keeps evidence-style metrics out of the reputation pillar
+- it is easier to explain and implement than a nested source-score formula
+- it keeps Google as the anchor while giving Reddit and HRN equal forum weight
+
+### Google
+
+Google is the anchor reputation source.
+
+#### Inputs
+
+- `clinic_google_places.rating`
+- `clinic_google_places.user_ratings_total`
+
+#### Weighting
+
+- `google_rating_score`: `35%`
+- `google_review_signal`: `15%`
+
+#### Guidance
+
+- `google_rating_score` is the primary Google input.
+- `google_review_signal` is a modest credibility input.
+- Review count should matter, but should not overpower the actual rating.
+
+#### Suggested Normalization
+
+- `google_rating_score`
+  - map approximately `3.5 to 5.0` onto `0-100`
+  - clinics below `3.5` should fall near the floor
+- `google_review_signal`
+  - use a saturating curve rather than a linear scale
+  - rough intuition:
+    - `0 reviews -> 0`
+    - `20 reviews -> 40`
+    - `100 reviews -> 75`
+    - `300+ reviews -> 100`
+
+### Reddit
+
+Reddit is a forum/community reputation source.
+
+#### Inputs
+
+From `clinic_forum_profiles` and `forum_thread_llm_analysis`:
+
+- `sentiment_score`
+- `repair_mention_count`
+
+#### Weighting
+
+- `reddit_sentiment_score`: `20%`
+- `reddit_caution_penalty`: `10%` negative weight
+
+#### Guidance
+
+- Sentiment should dominate the positive side of Reddit reputation.
+- Repair / caution should act as a penalty, not a positive subscore.
+- Reputation should not directly include extra evidence metrics such as thread volume or unique authors in this version.
+
+#### Suggested Normalization
+
+- `reddit_sentiment_score`
+  - map `-1..1` to `0..100`
+- `reddit_caution_penalty`
+  - normalize to `0..100`
+  - derive only from repair signals for v1.5
+
+#### Caution Formula
+
+```text
+reddit_caution_penalty =
+  min(
+    100,
+    50 * has_any_repair_signal
+  + 15 * min(repair_thread_count, 3)
+  )
+```
+
+Where:
+
+- `has_any_repair_signal = 1 if repair_mention_count > 0 else 0`
+- `repair_thread_count = repair_mention_count`
+
+### HRN
+
+HRN is a forum/case-history reputation source.
+
+#### Inputs
+
+From `clinic_forum_profiles` and `forum_thread_llm_analysis`:
+
+- `sentiment_score`
+- `repair_mention_count`
+
+#### Weighting
+
+- `hrn_sentiment_score`: `20%`
+- `hrn_caution_penalty`: `10%` negative weight
+
+#### Guidance
+
+- HRN sentiment should mirror Reddit sentiment in top-level weighting.
+- HRN caution / repair signals should remain a meaningful negative factor.
+- For v1.5, use the same repair-based caution structure as Reddit for simplicity and symmetry.
+
+#### Suggested Normalization
+
+- `hrn_sentiment_score`
+  - map `-1..1` to `0..100`
+- `hrn_caution_penalty`
+  - normalize to `0..100`
+  - derive only from repair signals for v1.5
+
+#### Caution Formula
+
+```text
+hrn_caution_penalty =
+  min(
+    100,
+    50 * has_any_repair_signal
+  + 15 * min(repair_thread_count, 3)
+  )
+```
+
+Where:
+
+- `has_any_repair_signal = 1 if repair_mention_count > 0 else 0`
+- `repair_thread_count = repair_mention_count`
+
+### Instagram Boost
+
+Instagram should be a small additive boost, not a real weighted source.
+
+#### Formula
+
+```text
+instagram_boost = 0 to +5
+```
+
+#### Inputs
+
+From `clinic_social_media` and `clinic_instagram_posts`:
+
+- account exists
+- recent posting activity
+- basic engagement sanity
+- optional profile completeness signals
+
+#### Suggested Rubric
+
+- no account or dormant account: `0`
+- active account, limited signal: `+1`
+- active and reasonably credible presence: `+2 to +3`
+- very strong public-facing presence: `+4 to +5`
+
+#### Rule
+
+Instagram can help a little, but should never:
+
+- rescue a weak clinic
+- outweigh negative Google / Reddit / HRN signals
+- dominate the `Reputation` pillar
+
+### Example Calculation
+
+```text
+google_rating_score = 84
+google_review_signal = 70
+reddit_sentiment_score = 68
+reddit_caution_penalty = 20
+hrn_sentiment_score = 74
+hrn_caution_penalty = 10
+instagram_boost = 3
+
+Reputation =
+  0.35*84
++ 0.15*70
++ 0.20*68
+- 0.10*20
++ 0.20*74
+- 0.10*10
++ 3
+
+= 29.4
++ 10.5
++ 13.6
+- 2
++ 14.8
+- 1
++ 3
+
+= 68.3
+```
+
+## Evidence & Transparency Pillar v1.5
+
+This section captures the current proposed v1.5 implementation for the `Evidence & Transparency` pillar.
+
+### Top-Level Structure
+
+```text
+Evidence & Transparency = 100%
+
+Independent evidence = 55%
+Verification = 35%
+Breadth / coverage = 10%
+```
+
+### Why This Redistribution Works
+
+#### Independent Evidence — 55%
+
+This becomes the clear dominant signal:
+
+- hardest to fake at scale
+- strongest proxy for real patient outcomes and real-world experience
+- rewards corroboration, depth, and time
+
+#### Verification — 35%
+
+This becomes a real legitimacy floor:
+
+- prevents "popular but weakly verified" clinics from looking too strong
+- keeps formal trust signals meaningfully represented
+
+#### Breadth / Coverage — 10%
+
+This remains useful, but proportionate:
+
+- rewards cross-ecosystem presence
+- does not let simple discoverability overpower stronger evidence
+
+### Final Recommended Version
+
+#### Independent Evidence — 55%
+
+- Reddit volume = `8%`
+- Reddit unique voices = `11%`
+- Reddit long-term evidence = `9%`
+- HRN threads = `5%`
+- HRN photo threads = `8%`
+- HRN 12m+ followups = `8%`
+- Google review volume = `6%`
+
+#### Verification — 35%
+
+- registry listed = `14%`
+- license / verifiable = `14%`
+- credentials / accreditations = `7%`
+
+#### Breadth / Coverage — 10%
+
+- source breadth = `10%`
+
+## Overall Score Default Weighting
+
+The current recommended default weighting for the final clinic score is:
+
+```text
+Overall Score =
+  0.60 * Reputation
++ 0.40 * Evidence & Transparency
+```
+
+### Why `60 / 40`
+
+- it gives `Reputation` the lead as the most intuitive public trust signal
+- it still gives `Evidence & Transparency` enough weight to matter materially
+- it avoids making the system feel too popularity-driven
+- it better reflects the fact that `Evidence & Transparency` is now a substantial pillar, not a thin supporting metric
+
+### Product Direction
+
+- `60 / 40` is the recommended default
+- this weighting may become user-adjustable later
+- if user adjustment is added, `60 / 40` should remain the baseline "balanced" setting
+
+## Source Summaries
+
+This section captures the current public source-summary decisions.
+
+### Google Summary
+
+The Google source summary should use the same underlying Google metrics that feed the `Reputation` pillar, but reweighted as a standalone Google-only score.
+
+```text
+Google Summary =
+  0.75 * google_rating_score
++ 0.25 * google_review_signal
+```
+
+#### Inputs
+
+- `clinic_google_places.rating`
+- `clinic_google_places.user_ratings_total`
+
+#### Why `75 / 25`
+
+- Google star rating is the primary thing users mean by "Google reputation"
+- review count adds credibility and context
+- review count should matter, but should not overpower the rating itself
+
+### Reddit and HRN Source Summaries
+
+- `Reddit summary` is being designed separately by another contributor
+- `HRN summary` is being designed separately by another contributor
+
+For now, the architecture assumes these source summaries will exist, but their internal scoring formulas are not defined in this document.

--- a/docs/architecture/clinic-scoring-schema.md
+++ b/docs/architecture/clinic-scoring-schema.md
@@ -1,0 +1,365 @@
+# Clinic Scoring Schema
+
+## Overview
+
+This document defines the proposed persistence layer for clinic scoring.
+
+The scoring system has three distinct layers:
+
+- source summaries
+- pillar scores
+- final overall scores
+
+Those layers should be persisted separately so the system remains:
+
+- auditable
+- versionable
+- explainable
+- easy to evolve as formulas change
+
+## Recommended Tables
+
+The proposed scoring subsystem uses three tables:
+
+- `clinic_source_scores`
+- `clinic_pillar_scores`
+- `clinic_overall_scores`
+
+These tables sit on top of the existing raw and aggregated source tables such as:
+
+- `clinic_google_places`
+- `clinic_forum_profiles`
+- `forum_thread_llm_analysis`
+- `clinic_scraped_data`
+- `clinic_credentials`
+- `clinic_team`
+
+## Why Separate Tables
+
+### `clinic_source_scores`
+
+Stores source-level public or internal summaries such as:
+
+- Google summary
+- future Reddit summary
+- future HRN summary
+
+This makes source summaries queryable and versioned without mixing them into pillar logic.
+
+### `clinic_pillar_scores`
+
+Stores the current pillar outputs:
+
+- `reputation_score`
+- `evidence_transparency_score`
+
+This is the core trust layer that sits between raw source data and the final score.
+
+### `clinic_overall_scores`
+
+Stores the final weighted clinic ranking score.
+
+This is the table that ranking, sorting, and public overall score displays should use.
+
+## Design Principles
+
+- Keep source summaries, pillars, and final scores separate.
+- Version every computed score row with `score_version`.
+- Use `is_current` so formulas can be revised without destructive updates.
+- Store scoring inputs and weighted breakdowns in `jsonb` for auditability.
+- Avoid forcing scoring into `clinic_facts`; it is the wrong abstraction for weighted score snapshots.
+
+## Proposed Table Definitions
+
+### `clinic_source_scores`
+
+One row per `clinic_id + source_name + score_version`.
+
+Use this for:
+
+- public Google source summary
+- future Reddit source summary
+- future HRN source summary
+
+Suggested `source_name` values:
+
+- `google`
+- `reddit`
+- `hrn`
+
+Suggested schema:
+
+```sql
+create table public.clinic_source_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  source_name text not null,
+  score_version text not null,
+
+  summary_score numeric(5,2) not null check (summary_score between 0 and 100),
+  confidence_score numeric(5,2) check (confidence_score between 0 and 100),
+
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  unique (clinic_id, source_name, score_version)
+);
+```
+
+Example `metrics_json` for Google:
+
+```json
+{
+  "google_rating_score": 84,
+  "google_review_signal": 70
+}
+```
+
+Example `breakdown_json` for Google:
+
+```json
+{
+  "weights": {
+    "google_rating_score": 0.75,
+    "google_review_signal": 0.25
+  }
+}
+```
+
+### `clinic_pillar_scores`
+
+One row per `clinic_id + score_version`.
+
+Suggested schema:
+
+```sql
+create table public.clinic_pillar_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  score_version text not null,
+
+  reputation_score numeric(5,2) not null check (reputation_score between 0 and 100),
+  evidence_transparency_score numeric(5,2) not null check (evidence_transparency_score between 0 and 100),
+
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  unique (clinic_id, score_version)
+);
+```
+
+Example `metrics_json`:
+
+```json
+{
+  "google_rating_score": 84,
+  "google_review_signal": 70,
+  "reddit_sentiment_score": 68,
+  "reddit_caution_penalty": 20,
+  "hrn_sentiment_score": 74,
+  "hrn_caution_penalty": 10,
+  "instagram_boost": 3,
+  "reddit_volume_score": 72,
+  "reddit_unique_voices_score": 80,
+  "hrn_photo_threads_score": 76
+}
+```
+
+### `clinic_overall_scores`
+
+One row per `clinic_id + score_version`.
+
+Suggested schema:
+
+```sql
+create table public.clinic_overall_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  score_version text not null,
+
+  overall_score numeric(5,2) not null check (overall_score between 0 and 100),
+  reputation_weight numeric(5,2) not null check (reputation_weight between 0 and 1),
+  evidence_transparency_weight numeric(5,2) not null check (evidence_transparency_weight between 0 and 1),
+
+  band text,
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  unique (clinic_id, score_version)
+);
+```
+
+For the current default model:
+
+- `reputation_weight = 0.60`
+- `evidence_transparency_weight = 0.40`
+
+## Indexes
+
+Recommended indexes:
+
+```sql
+create index idx_clinic_source_scores_clinic_id
+  on public.clinic_source_scores(clinic_id);
+
+create index idx_clinic_source_scores_source_name
+  on public.clinic_source_scores(source_name);
+
+create index idx_clinic_source_scores_current
+  on public.clinic_source_scores(source_name, clinic_id)
+  where is_current = true;
+
+create index idx_clinic_pillar_scores_clinic_id
+  on public.clinic_pillar_scores(clinic_id);
+
+create index idx_clinic_pillar_scores_current
+  on public.clinic_pillar_scores(clinic_id)
+  where is_current = true;
+
+create index idx_clinic_overall_scores_clinic_id
+  on public.clinic_overall_scores(clinic_id);
+
+create index idx_clinic_overall_scores_current
+  on public.clinic_overall_scores(clinic_id)
+  where is_current = true;
+
+create index idx_clinic_overall_scores_score
+  on public.clinic_overall_scores(overall_score desc)
+  where is_current = true;
+```
+
+## Migration Proposal
+
+Below is the proposed migration SQL for introducing the scoring tables.
+
+```sql
+-- Create scoring persistence tables for source summaries, pillar scores,
+-- and final overall clinic scores.
+
+create table public.clinic_source_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  source_name text not null,
+  score_version text not null,
+
+  summary_score numeric(5,2) not null
+    check (summary_score between 0 and 100),
+  confidence_score numeric(5,2)
+    check (confidence_score between 0 and 100),
+
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  constraint clinic_source_scores_unique
+    unique (clinic_id, source_name, score_version)
+);
+
+create table public.clinic_pillar_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  score_version text not null,
+
+  reputation_score numeric(5,2) not null
+    check (reputation_score between 0 and 100),
+  evidence_transparency_score numeric(5,2) not null
+    check (evidence_transparency_score between 0 and 100),
+
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  constraint clinic_pillar_scores_unique
+    unique (clinic_id, score_version)
+);
+
+create table public.clinic_overall_scores (
+  id uuid primary key default gen_random_uuid(),
+  clinic_id uuid not null references clinics(id) on delete cascade,
+
+  score_version text not null,
+
+  overall_score numeric(5,2) not null
+    check (overall_score between 0 and 100),
+  reputation_weight numeric(5,2) not null
+    check (reputation_weight between 0 and 1),
+  evidence_transparency_weight numeric(5,2) not null
+    check (evidence_transparency_weight between 0 and 1),
+
+  band text,
+  metrics_json jsonb not null default '{}'::jsonb,
+  breakdown_json jsonb not null default '{}'::jsonb,
+  explanation text,
+
+  computed_at timestamptz not null default now(),
+  is_current boolean not null default true,
+
+  constraint clinic_overall_scores_unique
+    unique (clinic_id, score_version)
+);
+
+create index idx_clinic_source_scores_clinic_id
+  on public.clinic_source_scores(clinic_id);
+
+create index idx_clinic_source_scores_source_name
+  on public.clinic_source_scores(source_name);
+
+create index idx_clinic_source_scores_current
+  on public.clinic_source_scores(source_name, clinic_id)
+  where is_current = true;
+
+create index idx_clinic_pillar_scores_clinic_id
+  on public.clinic_pillar_scores(clinic_id);
+
+create index idx_clinic_pillar_scores_current
+  on public.clinic_pillar_scores(clinic_id)
+  where is_current = true;
+
+create index idx_clinic_overall_scores_clinic_id
+  on public.clinic_overall_scores(clinic_id);
+
+create index idx_clinic_overall_scores_current
+  on public.clinic_overall_scores(clinic_id)
+  where is_current = true;
+
+create index idx_clinic_overall_scores_score
+  on public.clinic_overall_scores(overall_score desc)
+  where is_current = true;
+```
+
+## Implementation Notes
+
+- `clinic_source_scores` is useful even if only Google summary is defined right now, because Reddit and HRN summaries are expected to follow.
+- `metrics_json` should store the normalized metric snapshot used at compute time.
+- `breakdown_json` should store the weights or component contributions used to produce the score.
+- `is_current` allows keeping historical scoring versions without destructive updates.
+- If desired later, the current `clinic_scores` table can be deprecated in favor of `clinic_overall_scores`, or kept as a thin compatibility layer.
+
+## Suggested Migration Filename
+
+If this is implemented as a real Supabase migration, a reasonable filename would be:
+
+`supabase/migrations/20260429000000_create_clinic_scoring_tables.sql`

--- a/docs/features/bookmarks-and-consultations.md
+++ b/docs/features/bookmarks-and-consultations.md
@@ -1,0 +1,181 @@
+# Bookmarks & Consultations — Implementation Notes
+
+**Branch:** `feature/consultations`  
+**Spec:** `/docs/specs/consultation-cart-spec.md`  
+**Status:** Built, untested. DB migration not yet applied locally.
+
+---
+
+## Overview
+
+Two independent actions on every clinic:
+
+| Action | UI | Storage |
+|---|---|---|
+| Bookmark | Bookmark icon (outline → filled) | `user_bookmarks` table |
+| Request Consultation | "Request Free Consultation" text link | `consultations` table + email to team |
+
+Both require Google sign-in. No profile wizard required. Emails go to the Istanbul Medic Connect team (concierge model) — not directly to clinics.
+
+---
+
+## Before you can test locally
+
+```bash
+# 1. Apply migration + reset local DB
+supabase db reset
+
+# 2. Regenerate TypeScript types (fixes TS errors in API routes)
+supabase gen types typescript --local > lib/supabase/database.types.ts
+
+# 3. Re-seed from production
+npx tsx scripts/seedLocalDb.ts
+```
+
+---
+
+## Files changed
+
+### Deleted (Phase 1 cleanup)
+- `contexts/ConsultationCartContext.tsx`
+- `app/consultations/cart/page.tsx`
+
+### New
+| File | Purpose |
+|---|---|
+| `supabase/migrations/20260506000000_create_bookmarks_and_consultations.sql` | DB schema |
+| `components/istanbulmedic-connect/BookmarkButton.tsx` | Shared bookmark icon component |
+| `app/bookmarks/page.tsx` | Saved clinics page with bulk request |
+| `app/api/bookmarks/route.ts` | GET / POST / DELETE bookmarks |
+| `app/api/consultations/route.ts` | POST (submit) / GET (list) consultations |
+| `lib/email/sendConsultationRequest.ts` | Resend email stub |
+
+### Modified
+| File | What changed |
+|---|---|
+| `app/auth/callback/route.ts` | Removed forced wizard redirect — always honours `next` cookie |
+| `app/layout.tsx` | Removed `ConsultationCartProvider` |
+| `components/istanbulmedic-connect/ConsultationConfirmModal.tsx` | Updated copy for new flows |
+| `components/istanbulmedic-connect/ClinicCard.tsx` | Cart button → bookmark icon + consultation text link |
+| `components/istanbulmedic-connect/profile/SummarySidebar.tsx` | Cart button → bookmark + consultation text link |
+| `components/istanbulmedic-connect/TopNav.tsx` | Cart badge → bookmark icon link (auth-gated) |
+| `components/istanbulmedic-connect/user-profile/sections/ProfileConsultations.tsx` | "Coming Soon" → real data table |
+| `scripts/seedLocalDb.ts` | Added wipe step before upsert |
+
+---
+
+## Database schema
+
+### `user_bookmarks`
+```sql
+id UUID PK
+user_id UUID → users(id)
+clinic_id UUID → clinics(id)
+created_at TIMESTAMPTZ
+UNIQUE(user_id, clinic_id)
+```
+
+### `consultations`
+```sql
+id UUID PK
+user_id UUID → users(id)
+clinic_id UUID → clinics(id)
+status consultation_status DEFAULT 'pending'
+user_email TEXT NOT NULL   -- snapshotted at request time
+user_name TEXT
+created_at / updated_at TIMESTAMPTZ
+```
+
+**Partial unique index:** `(user_id, clinic_id) WHERE status = 'pending'` — prevents duplicate active requests but allows re-requesting after completion/cancellation.
+
+### `consultation_status` enum
+`pending` → `in_progress` → `completed` / `cancelled`
+
+MVP only uses `pending`.
+
+---
+
+## Schema gotcha
+
+The `clinics` table does NOT have `name`, `location`, `image`, `rating`, or `review_count` columns directly. The API routes account for this:
+
+| Needed | Actual source |
+|---|---|
+| `name` | `clinics.display_name` |
+| `location` | `${primary_city}, ${primary_country}` |
+| `image` | `clinic_media` join (where `is_primary=true`, `media_type='image'`) |
+| `rating` | `clinic_google_places.rating` |
+| `reviewCount` | `clinic_google_places.user_ratings_total` |
+
+---
+
+## UI behaviour
+
+### BookmarkButton
+- Unauthenticated click → sets `auth_redirect_next` cookie → redirects to `/auth/login`
+- Authenticated, not bookmarked → POST `/api/bookmarks` optimistically (reverts on error)
+- Authenticated, already bookmarked → opens `ConsultationConfirmModal` (isRemoving=true) → DELETE `/api/bookmarks`
+- Used in: `ClinicCard` (top-right image overlay), `SummarySidebar` (icon link row), `BookmarksPage` (inline)
+
+### Consultation request
+- Unauthenticated → same auth redirect flow
+- Authenticated → opens `ConsultationConfirmModal` (isRemoving=false)
+- On confirm → POST `/api/consultations` → shows "Consultation Requested ✓" state
+- Bulk request on bookmarks page → single POST with `clinicIds: string[]` → one DB row per clinic, one email listing all
+
+### Auth callback
+Before: new users without `terms_accepted` were force-redirected to `/profile/get-started`.  
+After: always redirects to `next` cookie value, falls back to `/profile`. Wizard is opt-in.
+
+---
+
+## Email (Resend)
+
+Currently a stub — logs to console only. To activate:
+
+```bash
+npm install resend
+```
+
+`.env.local`:
+```
+RESEND_API_KEY=re_...
+CONSULTATION_EMAIL=consultations@istanbulmedic.com
+```
+
+Uncomment the send block in `lib/email/sendConsultationRequest.ts`.
+
+Email format:
+```
+Subject: [Istanbul Medic Connect] New Consultation Request — {User Name}
+
+User: {name}
+Email: {email}
+
+Clinics requested:
+- Clinic A
+- Clinic B
+
+---
+Please follow up with the user and the relevant clinic(s).
+```
+
+---
+
+## Testing checklist
+
+- [ ] `supabase db reset` + regen types + `seedLocalDb.ts` runs clean
+- [ ] TS errors gone in `app/api/bookmarks/route.ts` and `app/api/consultations/route.ts`
+- [ ] ClinicCard: bookmark icon renders top-right on image, fills on click
+- [ ] ClinicCard: "Request Free Consultation" link → modal → "Consultation Requested ✓"
+- [ ] SummarySidebar: same flows, visually consistent with other icon links
+- [ ] TopNav: bookmark icon visible only when authenticated, hidden when signed out
+- [ ] Unauthenticated bookmark click → sign in → back to clinic page (check `next` cookie)
+- [ ] Bookmarks page: empty state
+- [ ] Bookmarks page: populated list with clinic name, location, rating
+- [ ] Bookmarks page: per-clinic request button → "Requested" badge
+- [ ] Bookmarks page: multi-select → bulk request → all show "Requested"
+- [ ] Bookmarks page: remove bookmark via filled icon → confirmation modal
+- [ ] ProfileConsultations tab: shows submitted requests with clinic + date + "Pending" badge
+- [ ] ProfileConsultations tab: empty state links to /clinics and /bookmarks
+- [ ] Console log confirms email stub fires on consultation request

--- a/docs/reviews/reddit-integration-pr-review.md
+++ b/docs/reviews/reddit-integration-pr-review.md
@@ -1,0 +1,156 @@
+# PR Review: reddit-integration
+
+Branch: `feature/reddit-integration`
+Reviewed: 2026-04-23
+
+---
+
+## Status
+
+| Priority | Count | Status |
+|----------|-------|--------|
+| Blocker | 1 | Must fix before merge |
+| High | 4 | Fix before merge |
+| Medium | 4 | Strongly recommended |
+| Low | 4 | Post-merge cleanup |
+
+`database.types.ts` was empty at time of review — regenerated via `npm run db:types`, now resolved.
+
+---
+
+## Blocker
+
+### Missing tests
+
+The PR description claims 105 unit tests across `tests/api/forumPipeline/` and `tests/api/redditPipeline/`. Neither directory exists in the branch. These need to be located or rewritten before merging.
+
+---
+
+## High — fix before merging
+
+### 1. Race condition in `upsertThread()`
+
+**File:** [app/api/redditPipeline/redditPipeline.ts:55-86](../app/api/redditPipeline/redditPipeline.ts)
+
+The upsert uses `ignoreDuplicates: true`, which returns no data on a conflict. When that happens the code does a second query to fetch the existing row's ID. If two scrape processes run concurrently, the row could be deleted between those two operations, leaving `threadId = null` and silently dropping the post.
+
+**Fix:** Use a single atomic upsert that always returns the ID regardless of whether the row was inserted or already existed.
+
+---
+
+### 2. Silent failures in `profileAggregator.ts`
+
+**File:** [app/api/forumPipeline/profileAggregator.ts:106-126, 260-285](../app/api/forumPipeline/profileAggregator.ts)
+
+Nearly every Supabase query omits `error` from the destructure — only `data` is captured. If the DB is unavailable or a query fails, `data` is `undefined`, the code continues with empty arrays, and a blank or incorrect profile gets written with no indication anything went wrong.
+
+**Fix:** Every query needs `const { data, error } = await ...` with an explicit error throw or log.
+
+---
+
+### 3. LLM response cast without runtime validation
+
+**File:** [app/api/forumPipeline/llmAttributor.ts:178](../app/api/forumPipeline/llmAttributor.ts)
+
+```ts
+return JSON.parse(text.trim()) as LlmOutput
+```
+
+This is a bare TypeScript cast with no runtime validation. If the model returns a different shape — missing fields, wrong types, a field that's null when the code expects an array — the type system won't catch it and downstream code will either crash or silently write corrupt data.
+
+**Fix:** Validate against a Zod schema before casting.
+
+---
+
+### 4. Silent failures in `loadClinicNames()`
+
+**File:** [app/api/forumPipeline/llmAttributor.ts:290-332](../app/api/forumPipeline/llmAttributor.ts)
+
+Three Supabase queries (clinics, clinic_facts, clinic_team) have no error handling. If any fail, the function returns a partial or empty list silently. Attribution then runs against incomplete clinic data and threads that should match won't — with no error surfaced to explain why.
+
+**Fix:** Destructure and throw errors from all three queries.
+
+---
+
+## Medium — strongly recommended
+
+### 5. No LLM cost controls
+
+**Files:** [app/api/forumPipeline/llmAttributor.ts:168-183](../app/api/forumPipeline/llmAttributor.ts), [app/api/forumPipeline/profileAggregator.ts:49-67](../app/api/forumPipeline/profileAggregator.ts)
+
+`attributeThread()` makes one LLM call per thread with only a 200ms delay between them. `generateSummary()` makes one call per clinic profile. There's no concurrent request limit, no token budget, and no circuit breaker. At low volumes this is fine, but a bug causing a tight loop or a large backlog of unattributed threads could generate significant unexpected OpenAI spend.
+
+**Fix:** At minimum, add `max_tokens` to the attribution call (already present on the summary call at 200 tokens) and document the expected cost per full pipeline run.
+
+---
+
+### 6. Attribution prompt doesn't distinguish primary vs. passing mention
+
+**File:** [app/api/forumPipeline/llmAttributor.ts:158](../app/api/forumPipeline/llmAttributor.ts)
+
+The prompt instructs the LLM to return `attributed_clinic_name: "<exact name from list, or null>"` without specifying that the post should be *primarily about* that clinic. A post that only mentions a clinic in passing (e.g. "I considered Clinic A but went elsewhere") could get attributed to it, polluting that clinic's sentiment profile.
+
+The LLM is always called even when the fast substring match fires, so this is a one-line fix.
+
+**Fix:** Change the prompt field description to:
+```
+"attributed_clinic_name": "<exact name from list if the post is PRIMARILY about that clinic, or null if the clinic is only mentioned in passing>"
+```
+
+No logic changes needed.
+
+---
+
+### 7. Scripts log errors but exit with code 0
+
+**File:** [scripts/forum-attribute-threads.ts:191-200](../scripts/forum-attribute-threads.ts)
+
+When `attributeThread()` returns an error the script logs it, increments `failed`, and continues the loop — exiting with code 0 regardless. A critical failure like "no clinic names loaded" or "DB unavailable" is indistinguishable from a successful run with some unmatched threads.
+
+**Fix:** Exit with a non-zero code when `failed > 0`, so CI or a cron job can detect failures.
+
+---
+
+### 8. No RLS policies on new tables
+
+**File:** [supabase/migrations/20260409000000_create_forum_scraping_tables.sql](../supabase/migrations/20260409000000_create_forum_scraping_tables.sql)
+
+All six new tables (`forum_thread_index`, `reddit_thread_content`, `hrn_thread_content`, `forum_thread_signals`, `forum_thread_llm_analysis`, `clinic_forum_profiles`) have no row-level security policies. Acceptable if these tables are strictly backend-only and never queried with the anon key, but this should be explicitly documented. If the anon key is ever used to query these tables from the client, all data would be exposed.
+
+**Fix:** Either add RLS policies, or add a comment in the migration explaining why they're intentionally omitted and confirming these tables are service-role-only.
+
+---
+
+## Low — post-merge cleanup
+
+### 9. `openai` is not an explicit dependency
+
+The code imports from `openai` directly but the package isn't listed in `package.json` — it arrives transitively via `@langchain/openai`. This works until a package manager update changes the transitive tree.
+
+**Fix:** Add `"openai"` explicitly to `dependencies` in `package.json`.
+
+---
+
+### 10. Hardcoded request timeout
+
+**File:** [app/api/redditPipeline/redditService.ts:33](../app/api/redditPipeline/redditService.ts)
+
+`AbortSignal.timeout(15_000)` is hardcoded. In a slow network or staging environment this is often the first thing that causes mysterious failures.
+
+**Fix:** Extract to a named constant or `REDDIT_REQUEST_TIMEOUT_MS` env var.
+
+---
+
+### 11. No upfront env var validation
+
+Multiple files use `process.env.VAR!` non-null assertions. If a required env var is missing the error will be a cryptic null reference deep in the call stack.
+
+**Fix:** Add a guard at the top of each script entry point that checks required env vars and throws a clear message if any are missing.
+
+---
+
+### 12. Console logging throughout pipeline
+
+`console.info`, `console.warn`, `console.error` are used throughout the pipeline files. Fine for scripts, but in a production API context structured logging (Pino, Winston, etc.) makes it easier to filter, alert on, and correlate errors.
+
+**Fix:** Post-merge, replace with a shared logger instance.

--- a/docs/specs/consultation-cart-spec.md
+++ b/docs/specs/consultation-cart-spec.md
@@ -1,0 +1,285 @@
+# Consultation & Bookmarks — Feature Spec
+
+## Overview
+
+Two distinct actions on every clinic: **bookmark** (save for later) and **request a free consultation** (fires immediately). Both require Google sign-in but nothing more — no profile wizard, no cart checkout flow.
+
+Istanbul Medic Connect acts as the concierge layer. Consultation request emails go to the **Connect team**, not directly to clinics. The team coordinates with the relevant clinic(s) on the user's behalf.
+
+---
+
+## Mental Model
+
+| Action | Intent | Where it goes |
+|--------|--------|---------------|
+| Bookmark | "I'm interested, save this for later" | `user_bookmarks` table, visible on Bookmarks page |
+| Request Free Consultation | "I want to talk to this clinic now" | `consultations` table, email to Connect team |
+
+These are independent — you can request without bookmarking, and bookmark without ever requesting. But the Bookmarks page doubles as a hub for bulk-requesting consultations across saved clinics.
+
+---
+
+## User Flows
+
+### Direct Consultation Request (from any clinic surface)
+1. User clicks **"Request Free Consultation"** text link on a clinic card or profile sidebar
+2. If not signed in → Google sign-in → **redirected back to clinic page** (no wizard)
+3. Confirmation modal: "Request a free consultation with [Clinic Name]?" → Confirm
+4. Request fires immediately → stored in `consultations` table → email sent to Connect team
+5. Success feedback (toast or inline) — no page change needed
+
+### Bookmarking
+1. User clicks **bookmark icon** on a clinic card or profile sidebar
+2. If not signed in → Google sign-in → redirected back to clinic page
+3. Clinic saved to `user_bookmarks` — icon fills to show saved state
+4. Clicking again opens remove confirmation modal
+
+### Bookmarks Page (`/bookmarks`)
+1. Shows all saved clinics, each with:
+   - Clinic card (name, image, location, rating)
+   - "Requested" badge if consultation already submitted
+   - "Request Consultation" button (disabled + badge if already requested)
+   - Remove bookmark button
+2. User can select multiple clinics and bulk-request consultations
+3. Bulk request fires one email listing all selected clinics, creates one record per clinic
+
+### Profile Consultations Tab
+- Shows all submitted consultation requests
+- Columns: Clinic, Date Submitted, Status
+- Status (MVP): `Pending` only (yellow badge)
+- Empty state: prompt to browse clinics or visit bookmarks
+
+---
+
+## Auth & Friction
+
+### The fix (one change)
+In `/app/auth/callback/route.ts`, the current logic forces new users to `/profile/get-started` if they haven't accepted terms. This breaks the "return to where you were" flow.
+
+**Change:** Always honour the `next` cookie. Never redirect to the wizard automatically.
+
+```ts
+// Before
+destination = hasConsented ? '/profile' : '/profile/get-started';
+
+// After
+destination = next ?? '/profile';
+```
+
+The wizard becomes fully opt-in — accessible from the profile dashboard, never forced.
+
+### Profile data and consultation requests
+Google OAuth already captures name + email. That's all we need for the consultation email. The wizard fields (budget, Norwood scale, timeline, etc.) are enrichment — useful but never required to submit a request.
+
+### What requires auth
+- Bookmarking a clinic
+- Requesting a consultation
+- Viewing bookmarks page
+- Viewing consultations tab
+
+### What does NOT require auth
+- Browsing clinics
+- Viewing clinic profiles
+- Talking to Leila
+
+---
+
+## UI/UX
+
+### "Request Free Consultation" button
+- Style: **text link / hyperlink style** — not a teal pill button
+- Label: "Request Free Consultation" (or "Request Consultation")
+- Locations: `ClinicCard` (bottom of card) + `SummarySidebar` (replaces current teal button)
+- States:
+  - Default: text link, teal colour
+  - Already requested: greyed out, "Consultation Requested" with a check
+
+### Bookmark icon
+- Style: bookmark icon (outline → filled when saved)
+- Locations: `ClinicCard` (top-right corner overlay or bottom action row) + `SummarySidebar` (icon action link, replaces disabled "Save Clinic")
+- States:
+  - Default: outline bookmark icon
+  - Saved: filled bookmark icon (teal)
+  - Hover when saved: red tint to signal "click to remove"
+
+### Confirmation modals (shared `ConsultationConfirmModal`)
+Used for all add/remove actions. Already built — just update copy:
+- **Request consultation**: "Request a free consultation with [Clinic Name]? The Istanbul Medic Connect team will be in touch."
+- **Remove bookmark**: "Remove [Clinic Name] from your saved clinics?"
+
+### Hover-to-reveal intent
+Already implemented for the request button. Apply same pattern to bookmark icon.
+
+---
+
+## Phase 1 — What Was Built (to be refactored)
+
+Phase 1 built a **cart-based** flow that is being replaced by the bookmark + direct request model. The following need to change:
+
+| Built in Phase 1 | New direction |
+|------------------|---------------|
+| `ConsultationCartContext` (localStorage) | Remove — bookmarks are DB-backed |
+| `/consultations/cart` page | Replace with `/bookmarks` page |
+| "Consult" pill button on `ClinicCard` | Replace with "Request Free Consultation" text link |
+| "Request Consultation" teal button on `SummarySidebar` | Replace with text link style |
+| Cart badge in `TopNav` | Replace with bookmark icon/count in nav |
+| `ConsultationCartProvider` in `layout.tsx` | Remove |
+
+**Keep from Phase 1:**
+- `ConsultationConfirmModal` component (reuse for both bookmark + request modals)
+- `GET /api/clinics` route (used by bookmarks page browser)
+- `bookConsultation` feature flag (stays `true`)
+
+---
+
+## Frontend — To Build
+
+### 1. Auth callback fix
+**File:** `/app/auth/callback/route.ts`
+- Remove forced redirect to `/profile/get-started`
+- Always use `next` cookie or fall back to `/profile`
+
+### 2. Bookmark button component
+**File:** `/components/istanbulmedic-connect/BookmarkButton.tsx`
+- Shared component used in `ClinicCard` and `SummarySidebar`
+- Handles auth gate, optimistic UI, DB call, confirmation modal on remove
+- Props: `clinicId`, `clinicName`
+
+### 3. Update `ClinicCard`
+- Remove cart button + `ConsultationCartContext` usage
+- Add `BookmarkButton` (icon style)
+- Add "Request Free Consultation" text link
+
+### 4. Update `SummarySidebar`
+- Remove cart button + context usage
+- Add `BookmarkButton` (icon action link style, alongside Visit Website etc.)
+- Replace teal button with "Request Free Consultation" text link
+
+### 5. Update `TopNav`
+- Remove cart badge/icon
+- Add bookmark count indicator (if user is signed in and has bookmarks)
+
+### 6. Bookmarks page
+**Route:** `/bookmarks`
+- List of saved clinics (fetched from `GET /api/bookmarks`)
+- Per-clinic: image, name, location, rating, "Requested" badge, "Request Consultation" button, remove bookmark
+- Multi-select + bulk request CTA
+- Empty state
+
+### 7. Update `layout.tsx`
+- Remove `ConsultationCartProvider`
+
+### 8. Profile Consultations tab
+**File:** `/components/istanbulmedic-connect/user-profile/sections/ProfileConsultations.tsx`
+- Replace "Coming Soon" stub with real data from `GET /api/consultations`
+- For now: mock data (swap in Phase 2)
+
+---
+
+## Backend — To Build
+
+### 1. Database migrations
+
+**File:** `/supabase/migrations/20260506000000_create_bookmarks_and_consultations.sql`
+
+```sql
+-- Bookmarks
+CREATE TABLE user_bookmarks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, clinic_id)
+);
+
+-- Consultations
+CREATE TYPE consultation_status AS ENUM ('pending', 'in_progress', 'completed', 'cancelled');
+
+CREATE TABLE consultations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  status consultation_status NOT NULL DEFAULT 'pending',
+  user_email TEXT NOT NULL,
+  user_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX consultations_pending_unique
+  ON consultations(user_id, clinic_id)
+  WHERE status = 'pending';
+
+CREATE TRIGGER update_consultations_updated_at
+  BEFORE UPDATE ON consultations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+```
+
+### 2. Bookmarks API
+**File:** `/app/api/bookmarks/route.ts`
+
+- `GET /api/bookmarks` — returns all bookmarks for logged-in user, joined with clinic name/location/image/rating
+- `POST /api/bookmarks` — `{ clinicId }` → insert, return bookmark
+- `DELETE /api/bookmarks` — `{ clinicId }` → delete
+
+### 3. Consultations API
+**File:** `/app/api/consultations/route.ts`
+
+- `POST /api/consultations` — `{ clinicIds: string[] }` → insert records, fire email, return `{ created, skipped }`
+- `GET /api/consultations` — returns all consultation records for logged-in user
+
+### 4. Email (Resend)
+**File:** `/lib/email/sendConsultationRequest.ts`
+
+- Install: `npm install resend`
+- Env vars: `RESEND_API_KEY`, `CONSULTATION_EMAIL` (team inbox)
+
+```
+Subject: [Istanbul Medic Connect] New Consultation Request — {User Name}
+
+User: {name}
+Email: {email}
+
+Clinics requested:
+- Clinic A
+- Clinic B
+
+---
+Please follow up with the user and the relevant clinic(s).
+```
+
+---
+
+## File Plan
+
+| Action | File | Notes |
+|--------|------|-------|
+| MODIFY | `/app/auth/callback/route.ts` | Remove forced wizard redirect |
+| CREATE | `/components/istanbulmedic-connect/BookmarkButton.tsx` | Shared bookmark component |
+| MODIFY | `/components/istanbulmedic-connect/ClinicCard.tsx` | Replace cart button with bookmark + text link |
+| MODIFY | `/components/istanbulmedic-connect/profile/SummarySidebar.tsx` | Replace cart button with bookmark + text link |
+| MODIFY | `/components/istanbulmedic-connect/TopNav.tsx` | Replace cart badge with bookmark indicator |
+| MODIFY | `/app/layout.tsx` | Remove `ConsultationCartProvider` |
+| DELETE | `/contexts/ConsultationCartContext.tsx` | Replaced by DB-backed bookmarks |
+| REPLACE | `/app/consultations/cart/page.tsx` → `/app/bookmarks/page.tsx` | New bookmarks page |
+| CREATE | `/app/api/bookmarks/route.ts` | Bookmarks CRUD |
+| CREATE | `/app/api/consultations/route.ts` | Consultation submit + list |
+| CREATE | `/lib/email/sendConsultationRequest.ts` | Resend email stub |
+| CREATE | `/supabase/migrations/20260506000000_create_bookmarks_and_consultations.sql` | DB schema |
+| MODIFY | `/components/istanbulmedic-connect/user-profile/sections/ProfileConsultations.tsx` | Replace stub |
+| KEEP | `/components/istanbulmedic-connect/ConsultationConfirmModal.tsx` | Reused for both flows |
+| KEEP | `/app/api/clinics/route.ts` | Used by bookmarks page |
+
+---
+
+## Phase Summary
+
+| Phase | Status |
+|-------|--------|
+| Phase 1 frontend (cart model) | Built — being refactored |
+| Auth callback fix | Not started |
+| Bookmark button + DB | Not started |
+| Bookmarks page | Not started |
+| Consultation text link + direct request | Not started |
+| Profile Consultations tab (mock) | Not started |
+| Backend: DB migration, API routes, email | Not started |

--- a/lib/email/sendConsultationRequest.ts
+++ b/lib/email/sendConsultationRequest.ts
@@ -1,0 +1,327 @@
+import { Resend } from 'resend'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ConsultationPassport {
+  // Profile
+  ageTier?: string | null
+  gender?: string | null
+  country?: string | null
+  budgetTier?: string | null
+  timeline?: string | null
+  whatsApp?: string | null
+  // Hair loss
+  norwoodScale?: number | null
+  durationYears?: number | null
+  donorAreaQuality?: string | null
+  donorAreaAvailability?: string | null
+  desiredDensity?: string | null
+  hadPriorTransplant?: boolean | null
+  priorTransplants?: { year: number; estimatedGrafts: number; clinicCountry: string }[]
+  // Medical
+  allergies?: string[]
+  medications?: string[]
+  otherConditions?: string[]
+  priorSurgeries?: { type: string; year: number; notes?: string }[]
+  // Photos
+  photos?: { view: string; url: string }[]
+}
+
+export interface SendConsultationRequestParams {
+  userName: string
+  userEmail: string
+  clinicNames: string[]
+  passport?: ConsultationPassport
+}
+
+// ─── Format helpers ───────────────────────────────────────────────────────────
+
+const AGE_TIER: Record<string, string> = {
+  '18_24': '18–24', '25_34': '25–34', '35_44': '35–44',
+  '45_54': '45–54', '55_64': '55–64', '65_plus': '65+',
+}
+const BUDGET_TIER: Record<string, string> = {
+  'under_2000': 'Under $2,000', '2000_5000': '$2,000–$5,000',
+  '5000_8000': '$5,000–$8,000', '8000_12000': '$8,000–$12,000',
+  '12000_plus': '$12,000+',
+}
+const TIMELINE: Record<string, string> = {
+  '1_3_months': '1–3 months', '3_6_months': '3–6 months',
+  '6_12_months': '6–12 months', '12_plus_months': '12+ months',
+}
+const PHOTO_LABEL: Record<string, string> = {
+  front: 'Front', left_side: 'Left Side', right_side: 'Right Side',
+  top: 'Top', donor_area: 'Donor Area',
+}
+
+function fe(val: string | null | undefined, map: Record<string, string>): string {
+  if (!val) return '<span style="color:#94a3b8">Not provided</span>'
+  return map[val] ?? val.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+function fv(val: string | number | null | undefined): string {
+  if (val === null || val === undefined || val === '') return '<span style="color:#94a3b8">Not provided</span>'
+  return String(val)
+}
+function fl(items: string[] | undefined): string {
+  if (!items || items.length === 0) return '<span style="color:#94a3b8">None</span>'
+  return items.join(', ')
+}
+// Plain-text equivalents
+function pe(val: string | null | undefined, map: Record<string, string>): string {
+  if (!val) return 'Not provided'
+  return map[val] ?? val.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+function pv(val: string | number | null | undefined): string {
+  return (val === null || val === undefined || val === '') ? 'Not provided' : String(val)
+}
+function pl(items: string[] | undefined): string {
+  return (!items || items.length === 0) ? 'None' : items.join(', ')
+}
+
+// ─── HTML builder ─────────────────────────────────────────────────────────────
+
+function row(label: string, value: string): string {
+  return `
+    <tr>
+      <td style="padding:7px 16px 7px 0;color:#64748b;font-size:13px;white-space:nowrap;vertical-align:top;width:160px;">${label}</td>
+      <td style="padding:7px 0;color:#0D1E32;font-size:13px;vertical-align:top;">${value}</td>
+    </tr>`
+}
+
+function section(title: string, content: string): string {
+  return `
+    <tr>
+      <td style="padding:24px 32px 0;">
+        <div style="border-left:3px solid #3EBBB7;padding-left:12px;margin-bottom:12px;">
+          <span style="font-size:11px;font-weight:700;letter-spacing:0.08em;color:#3EBBB7;text-transform:uppercase;">${title}</span>
+        </div>
+        <table cellpadding="0" cellspacing="0" width="100%">${content}</table>
+      </td>
+    </tr>`
+}
+
+function buildHtml({ userName, userEmail, clinicNames, passport: p }: SendConsultationRequestParams): string {
+  const date = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+
+  const clinicList = clinicNames
+    .map((n) => `<div style="padding:4px 0;color:#0D1E32;font-size:13px;">→ &nbsp;${n}</div>`)
+    .join('')
+
+  const priorTransplantValue = (() => {
+    if (!p) return fv(null)
+    if (p.hadPriorTransplant === false) return '<span style="color:#94a3b8">None</span>'
+    if (!p.priorTransplants?.length) return p.hadPriorTransplant ? fv('Yes') : fv(null)
+    return p.priorTransplants
+      .map((t) => `${t.year} · ${t.estimatedGrafts.toLocaleString()} grafts · ${t.clinicCountry}`)
+      .join('<br>')
+  })()
+
+  const priorSurgeryValue = (() => {
+    if (!p?.priorSurgeries?.length) return '<span style="color:#94a3b8">None</span>'
+    return p.priorSurgeries
+      .map((s) => `${s.type} (${s.year})${s.notes ? ` — ${s.notes}` : ''}`)
+      .join('<br>')
+  })()
+
+  const photoBlock = (() => {
+    if (!p?.photos?.length) return `<tr><td style="padding:7px 0;color:#94a3b8;font-size:13px;">No photos uploaded</td></tr>`
+    const links = p.photos
+      .map((ph) => `
+        <td style="padding:0 8px 8px 0;">
+          <a href="${ph.url}" target="_blank" style="display:block;text-decoration:none;">
+            <img src="${ph.url}" alt="${PHOTO_LABEL[ph.view] ?? ph.view}"
+              width="90" height="90"
+              style="display:block;border-radius:8px;object-fit:cover;border:1px solid #e2e8f0;" />
+            <span style="display:block;text-align:center;font-size:11px;color:#64748b;margin-top:4px;">
+              ${PHOTO_LABEL[ph.view] ?? ph.view}
+            </span>
+          </a>
+        </td>`)
+      .join('')
+    return `<tr><td colspan="2"><table cellpadding="0" cellspacing="0"><tr>${links}</tr></table></td></tr>`
+  })()
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:32px 16px;">
+  <tr><td align="center">
+    <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+
+      <!-- Header -->
+      <tr>
+        <td style="background:#0D1E32;padding:22px 32px;">
+          <span style="color:#3EBBB7;font-size:17px;font-weight:700;letter-spacing:0.06em;">ISTANBUL MEDIC CONNECT</span>
+        </td>
+      </tr>
+
+      <!-- Title -->
+      <tr>
+        <td style="padding:28px 32px 8px;">
+          <h1 style="margin:0 0 4px;font-size:21px;font-weight:700;color:#0D1E32;">New Consultation Request</h1>
+          <p style="margin:0;color:#94a3b8;font-size:12px;">${date}</p>
+        </td>
+      </tr>
+
+      <!-- Patient -->
+      ${section('Patient', `
+        ${row('Name', fv(userName))}
+        ${row('Email', `<a href="mailto:${userEmail}" style="color:#3EBBB7;text-decoration:none;">${userEmail}</a>`)}
+        ${row('WhatsApp', fv(p?.whatsApp))}
+      `)}
+
+      <!-- Clinics -->
+      <tr>
+        <td style="padding:24px 32px 0;">
+          <div style="border-left:3px solid #3EBBB7;padding-left:12px;margin-bottom:12px;">
+            <span style="font-size:11px;font-weight:700;letter-spacing:0.08em;color:#3EBBB7;text-transform:uppercase;">Clinics Requested</span>
+          </div>
+          ${clinicList}
+        </td>
+      </tr>
+
+      ${p ? `
+      <!-- Profile -->
+      ${section('Profile', `
+        ${row('Age Range', fe(p.ageTier, AGE_TIER))}
+        ${row('Gender', fv(p.gender ? p.gender.charAt(0).toUpperCase() + p.gender.slice(1) : null))}
+        ${row('Country', fv(p.country))}
+        ${row('Budget', fe(p.budgetTier, BUDGET_TIER))}
+        ${row('Timeline', fe(p.timeline, TIMELINE))}
+      `)}
+
+      <!-- Hair Loss -->
+      ${section('Hair Loss', `
+        ${row('Norwood Scale', fv(p.norwoodScale))}
+        ${row('Duration', p.durationYears != null ? `${p.durationYears} year${p.durationYears !== 1 ? 's' : ''}` : fv(null))}
+        ${row('Donor Quality', fv(p.donorAreaQuality ? p.donorAreaQuality.charAt(0).toUpperCase() + p.donorAreaQuality.slice(1) : null))}
+        ${row('Donor Availability', fv(p.donorAreaAvailability ? p.donorAreaAvailability.charAt(0).toUpperCase() + p.donorAreaAvailability.slice(1) : null))}
+        ${row('Desired Density', fv(p.desiredDensity ? p.desiredDensity.charAt(0).toUpperCase() + p.desiredDensity.slice(1) : null))}
+        ${row('Prior Transplant', priorTransplantValue)}
+      `)}
+
+      <!-- Medical -->
+      ${section('Medical History', `
+        ${row('Medications', fl(p.medications))}
+        ${row('Allergies', fl(p.allergies))}
+        ${row('Other Conditions', fl(p.otherConditions))}
+        ${row('Prior Surgeries', priorSurgeryValue)}
+      `)}
+
+      <!-- Photos -->
+      ${section('Photos', photoBlock)}
+      ` : ''}
+
+      <!-- Footer -->
+      <tr>
+        <td style="padding:28px 32px;margin-top:24px;border-top:1px solid #e2e8f0;background:#f8fafc;">
+          <p style="margin:0;color:#94a3b8;font-size:12px;line-height:1.6;">
+            Please follow up with the user and the relevant clinic(s).<br>
+            <strong style="color:#64748b;">Istanbul Medic Connect Concierge</strong>
+          </p>
+        </td>
+      </tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>`
+}
+
+// ─── Plain-text builder ───────────────────────────────────────────────────────
+
+function buildText({ userName, userEmail, clinicNames, passport: p }: SendConsultationRequestParams): string {
+  const date = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+  const hr = '─'.repeat(48)
+
+  const priorTransplants = (() => {
+    if (!p) return 'Not provided'
+    if (p.hadPriorTransplant === false) return 'None'
+    if (!p.priorTransplants?.length) return p.hadPriorTransplant ? 'Yes' : 'Not provided'
+    return p.priorTransplants.map((t) => `${t.year} · ${t.estimatedGrafts.toLocaleString()} grafts · ${t.clinicCountry}`).join('\n                   ')
+  })()
+
+  const priorSurgeries = !p?.priorSurgeries?.length
+    ? 'None'
+    : p.priorSurgeries.map((s) => `${s.type} (${s.year})${s.notes ? ` — ${s.notes}` : ''}`).join('; ')
+
+  const photos = !p?.photos?.length
+    ? 'None'
+    : p.photos.map((ph) => `${PHOTO_LABEL[ph.view] ?? ph.view}: ${ph.url}`).join('\n                   ')
+
+  return `
+ISTANBUL MEDIC CONNECT — New Consultation Request
+${date}
+${hr}
+
+PATIENT
+  Name       ${pv(userName)}
+  Email      ${userEmail}
+  WhatsApp   ${pv(p?.whatsApp)}
+
+CLINICS REQUESTED
+${clinicNames.map((n) => `  → ${n}`).join('\n')}
+
+${p ? `HAIR TRANSPLANT PASSPORT
+${hr}
+PROFILE
+  Age Range  ${pe(p.ageTier, AGE_TIER)}
+  Gender     ${pv(p.gender)}
+  Country    ${pv(p.country)}
+  Budget     ${pe(p.budgetTier, BUDGET_TIER)}
+  Timeline   ${pe(p.timeline, TIMELINE)}
+
+HAIR LOSS
+  Norwood    ${pv(p.norwoodScale)}
+  Duration   ${p.durationYears != null ? `${p.durationYears} year${p.durationYears !== 1 ? 's' : ''}` : 'Not provided'}
+  Donor Quality        ${pv(p.donorAreaQuality)}
+  Donor Availability   ${pv(p.donorAreaAvailability)}
+  Desired Density      ${pv(p.desiredDensity)}
+  Prior Transplant     ${priorTransplants}
+
+MEDICAL HISTORY
+  Medications          ${pl(p.medications)}
+  Allergies            ${pl(p.allergies)}
+  Other Conditions     ${pl(p.otherConditions)}
+  Prior Surgeries      ${priorSurgeries}
+
+PHOTOS
+  ${photos}
+` : '(Passport not yet completed)'}
+${hr}
+Please follow up with the user and the relevant clinic(s).
+Istanbul Medic Connect Concierge
+`.trim()
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+export async function sendConsultationRequest(params: SendConsultationRequestParams): Promise<void> {
+  const toEmail = process.env.CONSULTATION_EMAIL
+  if (!toEmail) {
+    console.warn('sendConsultationRequest: CONSULTATION_EMAIL not set — skipping email')
+    return
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('sendConsultationRequest: RESEND_API_KEY not set — skipping email')
+    return
+  }
+
+  const subject = `[Istanbul Medic Connect] New Consultation Request — ${params.userName}`
+  const from = process.env.CONSULTATION_FROM_EMAIL ?? 'Istanbul Medic Connect <noreply@istanbulmedic.com>'
+
+  const resend = new Resend(apiKey)
+
+  await resend.emails.send({
+    from,
+    to: [toEmail],
+    replyTo: params.userEmail,
+    subject,
+    html: buildHtml(params),
+    text: buildText(params),
+  })
+}

--- a/lib/email/sendConsultationRequest.ts
+++ b/lib/email/sendConsultationRequest.ts
@@ -301,14 +301,12 @@ Istanbul Medic Connect Concierge
 export async function sendConsultationRequest(params: SendConsultationRequestParams): Promise<void> {
   const toEmail = process.env.CONSULTATION_EMAIL
   if (!toEmail) {
-    console.warn('sendConsultationRequest: CONSULTATION_EMAIL not set — skipping email')
-    return
+    throw new Error('sendConsultationRequest: CONSULTATION_EMAIL not set')
   }
 
   const apiKey = process.env.RESEND_API_KEY
   if (!apiKey) {
-    console.warn('sendConsultationRequest: RESEND_API_KEY not set — skipping email')
-    return
+    throw new Error('sendConsultationRequest: RESEND_API_KEY not set')
   }
 
   const subject = `[Istanbul Medic Connect] New Consultation Request — ${params.userName}`

--- a/lib/email/sendConsultationRequest.ts
+++ b/lib/email/sendConsultationRequest.ts
@@ -296,6 +296,101 @@ Istanbul Medic Connect Concierge
 `.trim()
 }
 
+// ─── User confirmation email ──────────────────────────────────────────────────
+
+function buildConfirmationHtml(userName: string, clinicNames: string[]): string {
+  const clinicList = clinicNames
+    .map((n) => `<div style="padding:4px 0;color:#0D1E32;font-size:13px;">→ &nbsp;${n}</div>`)
+    .join('')
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:32px 16px;">
+  <tr><td align="center">
+    <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+
+      <!-- Header -->
+      <tr>
+        <td style="background:#0D1E32;padding:22px 32px;">
+          <span style="color:#3EBBB7;font-size:17px;font-weight:700;letter-spacing:0.06em;">ISTANBUL MEDIC CONNECT</span>
+        </td>
+      </tr>
+
+      <!-- Body -->
+      <tr>
+        <td style="padding:32px 32px 24px;">
+          <h1 style="margin:0 0 16px;font-size:21px;font-weight:700;color:#0D1E32;">Your request has been received</h1>
+          <p style="margin:0 0 20px;color:#334155;font-size:14px;line-height:1.7;">
+            Hi ${userName},<br><br>
+            Thank you for reaching out through Istanbul Medic Connect. We've notified the team about your interest in the following clinic${clinicNames.length > 1 ? 's' : ''}:
+          </p>
+          <div style="background:#f8fafc;border-radius:8px;padding:16px 20px;margin-bottom:20px;">
+            ${clinicList}
+          </div>
+          <p style="margin:0;color:#334155;font-size:14px;line-height:1.7;">
+            A member of our team will be in touch with you shortly to help coordinate your consultation.
+          </p>
+        </td>
+      </tr>
+
+      <!-- Footer -->
+      <tr>
+        <td style="padding:20px 32px 28px;border-top:1px solid #e2e8f0;background:#f8fafc;">
+          <p style="margin:0;color:#94a3b8;font-size:12px;line-height:1.6;">
+            <strong style="color:#64748b;">Istanbul Medic Connect</strong><br>
+            Your trusted partner for hair transplant consultations in Istanbul.
+          </p>
+        </td>
+      </tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>`
+}
+
+function buildConfirmationText(userName: string, clinicNames: string[]): string {
+  const hr = '─'.repeat(48)
+  return `
+ISTANBUL MEDIC CONNECT
+${hr}
+
+Hi ${userName},
+
+Thank you for reaching out through Istanbul Medic Connect. We've notified the team about your interest in the following clinic${clinicNames.length > 1 ? 's' : ''}:
+
+${clinicNames.map((n) => `  → ${n}`).join('\n')}
+
+A member of our team will be in touch with you shortly to help coordinate your consultation.
+
+Istanbul Medic Connect
+Your trusted partner for hair transplant consultations in Istanbul.
+`.trim()
+}
+
+export async function sendConsultationConfirmation(
+  params: Pick<SendConsultationRequestParams, 'userName' | 'userEmail' | 'clinicNames'>
+): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    throw new Error('sendConsultationConfirmation: RESEND_API_KEY not set')
+  }
+
+  const from = process.env.CONSULTATION_FROM_EMAIL ?? 'Istanbul Medic Connect <noreply@istanbulmedic.com>'
+  const resend = new Resend(apiKey)
+
+  await resend.emails.send({
+    from,
+    to: [params.userEmail],
+    subject: '[Istanbul Medic Connect] Your consultation request has been received',
+    html: buildConfirmationHtml(params.userName, params.clinicNames),
+    text: buildConfirmationText(params.userName, params.clinicNames),
+  })
+}
+
 // ─── Main export ──────────────────────────────────────────────────────────────
 
 export async function sendConsultationRequest(params: SendConsultationRequestParams): Promise<void> {

--- a/lib/filterConfig.ts
+++ b/lib/filterConfig.ts
@@ -67,7 +67,7 @@ export const FEATURE_CONFIG = {
   auth: false, // login/sign up
   compare: false,
   saveClinic: false,
-  bookConsultation: false,
+  bookConsultation: true,
   share: false, // TODO: implement copy URL to clipboard
   createProfile: false, // landing page "Create a profile" CTA
   personalizedOffers: false, // landing page "Receive Personalized Offers" step

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.1"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -772,163 +767,6 @@ export type Database = {
           },
         ]
       }
-      clinic_reddit_posts: {
-        Row: {
-          author_username: string | null
-          body: string | null
-          captured_at: string
-          clinic_id: string
-          comment_count: number | null
-          had_clinical_procedures: boolean | null
-          id: string
-          is_firsthand: boolean | null
-          medical_summary: string | null
-          post_type: Database["public"]["Enums"]["reddit_post_type"]
-          posted_at: string | null
-          reddit_post_id: string
-          score: number | null
-          seeking_medical_help: boolean | null
-          source_id: string | null
-          subreddit: string | null
-          title: string | null
-          url: string
-        }
-        Insert: {
-          author_username?: string | null
-          body?: string | null
-          captured_at?: string
-          clinic_id: string
-          comment_count?: number | null
-          had_clinical_procedures?: boolean | null
-          id?: string
-          is_firsthand?: boolean | null
-          medical_summary?: string | null
-          post_type: Database["public"]["Enums"]["reddit_post_type"]
-          posted_at?: string | null
-          reddit_post_id: string
-          score?: number | null
-          seeking_medical_help?: boolean | null
-          source_id?: string | null
-          subreddit?: string | null
-          title?: string | null
-          url: string
-        }
-        Update: {
-          author_username?: string | null
-          body?: string | null
-          captured_at?: string
-          clinic_id?: string
-          comment_count?: number | null
-          had_clinical_procedures?: boolean | null
-          id?: string
-          is_firsthand?: boolean | null
-          medical_summary?: string | null
-          post_type?: Database["public"]["Enums"]["reddit_post_type"]
-          posted_at?: string | null
-          reddit_post_id?: string
-          score?: number | null
-          seeking_medical_help?: boolean | null
-          source_id?: string | null
-          subreddit?: string | null
-          title?: string | null
-          url?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "clinic_reddit_posts_clinic_id_fkey"
-            columns: ["clinic_id"]
-            isOneToOne: false
-            referencedRelation: "clinics"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "clinic_reddit_posts_clinic_id_fkey"
-            columns: ["clinic_id"]
-            isOneToOne: false
-            referencedRelation: "clinics_with_scores"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "clinic_reddit_posts_source_id_fkey"
-            columns: ["source_id"]
-            isOneToOne: false
-            referencedRelation: "sources"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      clinic_reddit_profiles: {
-        Row: {
-          captured_at: string
-          caution_flags: Json | null
-          clinic_id: string
-          confidence_score: number | null
-          cons: string[] | null
-          id: string
-          last_mentioned_at: string | null
-          mention_count: number
-          notable_mentions: Json | null
-          pros: string[] | null
-          sentiment_score: number | null
-          summary: string | null
-          themes: Json | null
-          thread_count: number
-          unique_authors_count: number | null
-          updated_at: string
-        }
-        Insert: {
-          captured_at?: string
-          caution_flags?: Json | null
-          clinic_id: string
-          confidence_score?: number | null
-          cons?: string[] | null
-          id?: string
-          last_mentioned_at?: string | null
-          mention_count?: number
-          notable_mentions?: Json | null
-          pros?: string[] | null
-          sentiment_score?: number | null
-          summary?: string | null
-          themes?: Json | null
-          thread_count?: number
-          unique_authors_count?: number | null
-          updated_at?: string
-        }
-        Update: {
-          captured_at?: string
-          caution_flags?: Json | null
-          clinic_id?: string
-          confidence_score?: number | null
-          cons?: string[] | null
-          id?: string
-          last_mentioned_at?: string | null
-          mention_count?: number
-          notable_mentions?: Json | null
-          pros?: string[] | null
-          sentiment_score?: number | null
-          summary?: string | null
-          themes?: Json | null
-          thread_count?: number
-          unique_authors_count?: number | null
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "clinic_reddit_profiles_clinic_id_fkey"
-            columns: ["clinic_id"]
-            isOneToOne: true
-            referencedRelation: "clinics"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "clinic_reddit_profiles_clinic_id_fkey"
-            columns: ["clinic_id"]
-            isOneToOne: true
-            referencedRelation: "clinics_with_scores"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       clinic_registry_records: {
         Row: {
           authorized_specialties: string[] | null
@@ -1506,6 +1344,61 @@ export type Database = {
         }
         Relationships: []
       }
+      consultations: {
+        Row: {
+          clinic_id: string
+          created_at: string
+          id: string
+          status: Database["public"]["Enums"]["consultation_status"]
+          updated_at: string
+          user_email: string
+          user_id: string
+          user_name: string | null
+        }
+        Insert: {
+          clinic_id: string
+          created_at?: string
+          id?: string
+          status?: Database["public"]["Enums"]["consultation_status"]
+          updated_at?: string
+          user_email: string
+          user_id: string
+          user_name?: string | null
+        }
+        Update: {
+          clinic_id?: string
+          created_at?: string
+          id?: string
+          status?: Database["public"]["Enums"]["consultation_status"]
+          updated_at?: string
+          user_email?: string
+          user_id?: string
+          user_name?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "consultations_clinic_id_fkey"
+            columns: ["clinic_id"]
+            isOneToOne: false
+            referencedRelation: "clinics"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "consultations_clinic_id_fkey"
+            columns: ["clinic_id"]
+            isOneToOne: false
+            referencedRelation: "clinics_with_scores"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "consultations_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       fact_evidence: {
         Row: {
           clinic_fact_id: string
@@ -1803,6 +1696,7 @@ export type Database = {
           comment_count: number | null
           had_clinical_procedures: boolean | null
           is_firsthand: boolean | null
+          parent_thread_id: string | null
           post_type: string
           reddit_post_id: string
           score: number | null
@@ -1815,6 +1709,7 @@ export type Database = {
           comment_count?: number | null
           had_clinical_procedures?: boolean | null
           is_firsthand?: boolean | null
+          parent_thread_id?: string | null
           post_type: string
           reddit_post_id: string
           score?: number | null
@@ -1827,6 +1722,7 @@ export type Database = {
           comment_count?: number | null
           had_clinical_procedures?: boolean | null
           is_firsthand?: boolean | null
+          parent_thread_id?: string | null
           post_type?: string
           reddit_post_id?: string
           score?: number | null
@@ -1835,6 +1731,13 @@ export type Database = {
           thread_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "reddit_thread_content_parent_thread_id_fkey"
+            columns: ["parent_thread_id"]
+            isOneToOne: false
+            referencedRelation: "forum_thread_index"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "reddit_thread_content_thread_id_fkey"
             columns: ["thread_id"]
@@ -1911,6 +1814,49 @@ export type Database = {
           url?: string | null
         }
         Relationships: []
+      }
+      user_bookmarks: {
+        Row: {
+          clinic_id: string
+          created_at: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          clinic_id: string
+          created_at?: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          clinic_id?: string
+          created_at?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_bookmarks_clinic_id_fkey"
+            columns: ["clinic_id"]
+            isOneToOne: false
+            referencedRelation: "clinics"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_bookmarks_clinic_id_fkey"
+            columns: ["clinic_id"]
+            isOneToOne: false
+            referencedRelation: "clinics_with_scores"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "user_bookmarks_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_photos: {
         Row: {
@@ -2028,10 +1974,10 @@ export type Database = {
           created_at: string | null
           date_of_birth: string | null
           deleted: boolean | null
-          first_name: string
+          first_name: string | null
           gender: string | null
           id: string
-          last_name: string
+          last_name: string | null
           nationality: string | null
           preferred_language: string | null
           profile_picture_url: string | null
@@ -2043,10 +1989,10 @@ export type Database = {
           created_at?: string | null
           date_of_birth?: string | null
           deleted?: boolean | null
-          first_name: string
+          first_name?: string | null
           gender?: string | null
           id?: string
-          last_name: string
+          last_name?: string | null
           nationality?: string | null
           preferred_language?: string | null
           profile_picture_url?: string | null
@@ -2058,10 +2004,10 @@ export type Database = {
           created_at?: string | null
           date_of_birth?: string | null
           deleted?: boolean | null
-          first_name?: string
+          first_name?: string | null
           gender?: string | null
           id?: string
-          last_name?: string
+          last_name?: string | null
           nationality?: string | null
           preferred_language?: string | null
           profile_picture_url?: string | null
@@ -2362,6 +2308,7 @@ export type Database = {
         | "audit_finding"
       compliance_severity_enum: "low" | "medium" | "high" | "critical"
       computed_by_enum: "extractor" | "human" | "inquiry" | "model"
+      consultation_status: "pending" | "in_progress" | "completed" | "cancelled"
       desired_density: "maximum" | "high" | "medium" | "low"
       doc_type_enum: "html" | "pdf" | "post" | "comment" | "review"
       doctor_involvement_levels: "high" | "medium" | "low"
@@ -2383,7 +2330,6 @@ export type Database = {
         | "package_accuracy"
         | "before_after"
       photo_view: "front" | "left_side" | "right_side" | "top" | "donor_area"
-      reddit_post_type: "post" | "comment"
       registry_license_status_enum:
         | "active"
         | "expired"
@@ -2541,6 +2487,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       age_tier: ["18_24", "25_34", "35_44", "45_54", "55_64", "65_plus"],
@@ -2607,6 +2556,7 @@ export const Constants = {
       ],
       compliance_severity_enum: ["low", "medium", "high", "critical"],
       computed_by_enum: ["extractor", "human", "inquiry", "model"],
+      consultation_status: ["pending", "in_progress", "completed", "cancelled"],
       desired_density: ["maximum", "high", "medium", "low"],
       doc_type_enum: ["html", "pdf", "post", "comment", "review"],
       doctor_involvement_levels: ["high", "medium", "low"],
@@ -2629,7 +2579,6 @@ export const Constants = {
         "before_after",
       ],
       photo_view: ["front", "left_side", "right_side", "top", "donor_area"],
-      reddit_post_type: ["post", "comment"],
       registry_license_status_enum: [
         "active",
         "expired",
@@ -2669,3 +2618,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "^2.15.4",
+        "resend": "^6.12.3",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.25.76"
@@ -5852,6 +5853,12 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -11188,6 +11195,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -16737,6 +16750,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -18405,6 +18424,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
@@ -19156,6 +19196,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -19718,6 +19768,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^2.15.4",
+    "resend": "^6.12.3",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.25.76"

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,71 @@
+## What You Changed
+
+Added end-to-end HRN (Hair Restoration Network) forum scraping and display pipeline.
+
+**Key files to review:**
+- `app/api/hrnPipeline/hrnStoragePipeline.ts` — core pipeline: scrape → LLM extract → store in Supabase
+- `app/api/hrnPipeline/forumListingScraper.ts` — Playwright scraper that paginates HRN forum listings to collect thread URLs
+- `app/api/hrnPipeline/extractionPrompt.ts` — LLM prompt that extracts structured signals (sentiment, repair case, topics, clinic attribution) from raw thread text
+- `lib/api/hrn.ts` — data fetch layer: joins `forum_thread_index`, `hrn_thread_content`, `forum_thread_llm_analysis`, and `forum_thread_signals` to build the signals object for the UI
+- `lib/scoring/hrn.ts` — pure scoring function computing a 0–10 HRN score using recency-weighted sentiment, Bayesian shrinkage, repair case penalty, long-term follow-up bonus, and issue keyword penalty
+- `components/istanbulmedic-connect/profile/HRNSignalsCard.tsx` — UI card displaying the HRN score, sentiment breakdown, photo threads, long-term follow-up count, and notable threads
+- `lib/api/hrn.mock.ts` — mock data for local dev/demo (enabled via `NEXT_PUBLIC_USE_MOCK_HRN=true`)
+- `supabase/migrations/20260409000000_create_forum_scraping_tables.sql` — DB schema: `forum_thread_index` (hub), `hrn_thread_content` (HRN extension), `forum_thread_signals`, `forum_thread_llm_analysis`, `clinic_forum_profiles`
+
+## Why You Changed It
+
+HRN is the most trusted independent forum for hair transplant patient reviews. Adding it gives us a high-signal, unbiased data source for clinic reputation that's harder to fake than clinic-controlled channels. The pipeline is designed to be non-destructive — read-only on HRN, with LLM attribution running separately so raw data is preserved for re-analysis.
+
+The HRN card is currently **feature-flagged off** (`profileHRN: false` in `lib/filterConfig.ts`) pending approval to run the full production scrape.
+
+## Automated Tests
+
+3 test files, ~50 test cases:
+
+- `tests/unit/hrn-api.test.ts` — unit tests for `getHRNSignals`: null cases (no threads, DB error), correct aggregation of sentiment/topics/photo counts, mock fallback behaviour
+- `tests/unit/hrn-score.test.ts` — unit tests for `computeHRNScore`: recency decay, Bayesian shrinkage, repair penalty, long-term follow-up bonus, issue keyword penalty, minimum sample size threshold
+- `tests/unit/hrnEntityFilter.test.ts` — unit tests for the entity regex matcher used during clinic attribution in the storage pipeline
+
+**To run:**
+
+```bash
+# All HRN tests
+npx vitest tests/unit/hrn-api.test.ts tests/unit/hrn-score.test.ts tests/unit/hrnEntityFilter.test.ts
+
+# Or all unit tests
+npx vitest tests/unit/
+```
+
+## Manual Testing Steps
+
+To see the HRN card populated with mock data locally:
+
+1. Add to `.env.local`:
+```
+NEXT_PUBLIC_USE_MOCK_HRN=true
+```
+2. In `lib/filterConfig.ts`, set:
+```ts
+profileHRN: true,
+```
+3. Run `npm run dev` and open any clinic profile page
+4. Scroll to the bottom — you should see the **HRN Signals** card with score, sentiment breakdown, photo threads, and notable threads
+
+To test with real data (requires approved scrape):
+
+1. Run the listing scraper to collect thread URLs:
+```bash
+npx tsx app/api/hrnPipeline/forumListingScraper.ts
+```
+2. Run the storage pipeline to scrape, extract, and store:
+```bash
+npx tsx app/api/hrnPipeline/hrnStoragePipeline.ts --batch
+```
+3. Omit `NEXT_PUBLIC_USE_MOCK_HRN` (or set to `false`) and visit a clinic profile that has attributed threads
+
+## Future Steps
+
+- **TODO: set up GitHub Actions to run the automated tests** (currently running manually)
+- Get approval to run the full HRN production scrape, then enable `profileHRN: true` in `lib/filterConfig.ts`
+- Run `forum-attribute-threads.ts` and `forum-recompute-profiles.ts` after the scrape to populate `clinic_forum_profiles`
+- Consider a nightly cron to re-scrape threads marked `is_stale = true` in `clinic_forum_profiles`

--- a/scripts/forum-attribute-threads.ts
+++ b/scripts/forum-attribute-threads.ts
@@ -25,11 +25,12 @@
 import { createClient } from '@supabase/supabase-js'
 import dotenv from 'dotenv'
 import { attributeThread, analyzeSentimentOnly, loadClinicNames } from '../app/api/forumPipeline/llmAttributor'
+import WebSocket from 'ws'
 
 dotenv.config({ path: '.env.local' })
 
 // Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
-if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
+if (!globalThis.WebSocket) globalThis.WebSocket = WebSocket as unknown as typeof globalThis.WebSocket
 
 const {
   NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/forum-attribute-threads.ts
+++ b/scripts/forum-attribute-threads.ts
@@ -28,8 +28,17 @@ import { attributeThread, analyzeSentimentOnly, loadClinicNames } from '../app/a
 
 dotenv.config({ path: '.env.local' })
 
-const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY'] as const
-const missingEnv = REQUIRED_ENV.filter(k => !process.env[k])
+const {
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  OPENAI_API_KEY,
+} = process.env
+
+const missingEnv = [
+  !NEXT_PUBLIC_SUPABASE_URL && 'NEXT_PUBLIC_SUPABASE_URL',
+  !SUPABASE_SERVICE_ROLE_KEY && 'SUPABASE_SERVICE_ROLE_KEY',
+  !OPENAI_API_KEY && 'OPENAI_API_KEY',
+].filter(Boolean) as string[]
 if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)

--- a/scripts/forum-attribute-threads.ts
+++ b/scripts/forum-attribute-threads.ts
@@ -28,6 +28,9 @@ import { attributeThread, analyzeSentimentOnly, loadClinicNames } from '../app/a
 
 dotenv.config({ path: '.env.local' })
 
+// Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
+if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
+
 const {
   NEXT_PUBLIC_SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
@@ -158,6 +161,7 @@ async function main() {
       .from('forum_thread_llm_analysis')
       .select('thread_id')
       .eq('is_current', true)
+      .order('thread_id')
       .range(attemptedOffset, attemptedOffset + PAGE_SIZE - 1)
     if (attemptedError) throw new Error(`Failed to load attempted thread IDs: ${attemptedError.message}`)
     for (const r of page ?? []) attemptedIds.add(r.thread_id)
@@ -193,7 +197,7 @@ async function main() {
 
   if (!threads.length) {
     console.log('No unattributed threads found.')
-    return
+    if (!includeInheritedComments) return
   }
 
   console.log(`Found ${threads.length} unattributed threads. Starting attribution...\n`)
@@ -292,7 +296,7 @@ async function main() {
   while (inheritedThreads.length < inheritedLimit) {
     const { data: page, error: pageError } = await supabase
       .from('forum_thread_index')
-      .select('id, clinic_id, title, forum_source, reddit_thread_content(score)')
+      .select('id, clinic_id, title, forum_source, reddit_thread_content!reddit_thread_content_thread_id_fkey(score)')
       .eq('clinic_attribution_method', 'inherited')
       .eq('forum_source', inheritedSource)
       .order('first_scraped_at', { ascending: true })
@@ -302,8 +306,8 @@ async function main() {
 
     for (const row of page) {
       if (inheritedThreads.length >= inheritedLimit) break
-      const contentRows = row.reddit_thread_content as { score: number }[] | null
-      const score = contentRows?.[0]?.score ?? 0
+      const content = row.reddit_thread_content as unknown as { score: number } | null
+      const score = content?.score ?? 0
       if (!attemptedIds.has(row.id) && row.clinic_id && score >= minCommentUpvotes)
         inheritedThreads.push({ id: row.id, clinic_id: row.clinic_id, title: row.title, forum_source: row.forum_source })
     }

--- a/scripts/forum-attribute-threads.ts
+++ b/scripts/forum-attribute-threads.ts
@@ -22,7 +22,10 @@
  *   npx tsx scripts/forum-attribute-threads.ts --prune --dry-run   (shows count, deletes nothing)
  */
 
+import { createClient } from '@supabase/supabase-js'
 import dotenv from 'dotenv'
+import { attributeThread, analyzeSentimentOnly, loadClinicNames } from '../app/api/forumPipeline/llmAttributor'
+
 dotenv.config({ path: '.env.local' })
 
 const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY'] as const
@@ -31,9 +34,6 @@ if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)
 }
-
-import { createClient } from '@supabase/supabase-js'
-import { attributeThread, analyzeSentimentOnly, loadClinicNames } from '../app/api/forumPipeline/llmAttributor'
 
 function getSupabaseAdmin() {
   return createClient(

--- a/scripts/forum-recompute-profiles.ts
+++ b/scripts/forum-recompute-profiles.ts
@@ -10,7 +10,10 @@
  *   npx tsx scripts/forum-recompute-profiles.ts --clinic-id <uuid>
  */
 
+import { createClient } from '@supabase/supabase-js'
 import dotenv from 'dotenv'
+import { recomputeProfile, recomputeStaleProfiles } from '../app/api/forumPipeline/profileAggregator'
+
 dotenv.config({ path: '.env.local' })
 
 const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY'] as const
@@ -19,9 +22,6 @@ if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)
 }
-
-import { createClient } from '@supabase/supabase-js'
-import { recomputeProfile, recomputeStaleProfiles } from '../app/api/forumPipeline/profileAggregator'
 
 function getSupabaseAdmin() {
   return createClient(

--- a/scripts/forum-recompute-profiles.ts
+++ b/scripts/forum-recompute-profiles.ts
@@ -13,11 +13,12 @@
 import { createClient } from '@supabase/supabase-js'
 import dotenv from 'dotenv'
 import { recomputeProfile, recomputeStaleProfiles } from '../app/api/forumPipeline/profileAggregator'
+import WebSocket from 'ws'
 
 dotenv.config({ path: '.env.local' })
 
 // Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
-if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
+if (!globalThis.WebSocket) globalThis.WebSocket = WebSocket as unknown as typeof globalThis.WebSocket
 
 const {
   NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/forum-recompute-profiles.ts
+++ b/scripts/forum-recompute-profiles.ts
@@ -16,8 +16,17 @@ import { recomputeProfile, recomputeStaleProfiles } from '../app/api/forumPipeli
 
 dotenv.config({ path: '.env.local' })
 
-const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY'] as const
-const missingEnv = REQUIRED_ENV.filter(k => !process.env[k])
+const {
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  OPENAI_API_KEY,
+} = process.env
+
+const missingEnv = [
+  !NEXT_PUBLIC_SUPABASE_URL && 'NEXT_PUBLIC_SUPABASE_URL',
+  !SUPABASE_SERVICE_ROLE_KEY && 'SUPABASE_SERVICE_ROLE_KEY',
+  !OPENAI_API_KEY && 'OPENAI_API_KEY',
+].filter(Boolean) as string[]
 if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)

--- a/scripts/forum-recompute-profiles.ts
+++ b/scripts/forum-recompute-profiles.ts
@@ -16,6 +16,9 @@ import { recomputeProfile, recomputeStaleProfiles } from '../app/api/forumPipeli
 
 dotenv.config({ path: '.env.local' })
 
+// Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
+if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
+
 const {
   NEXT_PUBLIC_SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,

--- a/scripts/ingest-registry/sources/moh-pdf.ts
+++ b/scripts/ingest-registry/sources/moh-pdf.ts
@@ -39,7 +39,6 @@ if (typeof globalThis.DOMMatrix === 'undefined') {
 
 // pdf-parse is CJS-only; use createRequire to load it from ESM context
 const require = createRequire(import.meta.url)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { PDFParse } = require('pdf-parse') as { PDFParse: new (opts: { data: Buffer }) => { getText(): Promise<{ text: string }> } }
 
 export interface MOHPDFRow {

--- a/scripts/reddit-scrape-subreddits.ts
+++ b/scripts/reddit-scrape-subreddits.ts
@@ -24,11 +24,12 @@
 import dotenv from 'dotenv'
 import { runRedditPipeline } from '../app/api/redditPipeline/redditPipeline'
 import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline/redditConfig'
+import WebSocket from 'ws'
 
 dotenv.config({ path: '.env.local' })
 
 // Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
-if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
+if (!globalThis.WebSocket) globalThis.WebSocket = WebSocket as unknown as typeof globalThis.WebSocket
 
 const {
   NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/reddit-scrape-subreddits.ts
+++ b/scripts/reddit-scrape-subreddits.ts
@@ -26,8 +26,15 @@ import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline
 
 dotenv.config({ path: '.env.local' })
 
-const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] as const
-const missingEnv = REQUIRED_ENV.filter(k => !process.env[k])
+const {
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} = process.env
+
+const missingEnv = [
+  !NEXT_PUBLIC_SUPABASE_URL && 'NEXT_PUBLIC_SUPABASE_URL',
+  !SUPABASE_SERVICE_ROLE_KEY && 'SUPABASE_SERVICE_ROLE_KEY',
+].filter(Boolean) as string[]
 if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)

--- a/scripts/reddit-scrape-subreddits.ts
+++ b/scripts/reddit-scrape-subreddits.ts
@@ -18,6 +18,7 @@
  * Comments (all posts scraped; inherited comments affect score at 0.5 weight; run forum-attribute-threads --include-inherited-comments after):
  *   npx tsx scripts/reddit-scrape-subreddits.ts --include-comments
  *   npx tsx scripts/reddit-scrape-subreddits.ts --include-comments --comments-per-post 75
+ *   Default: 100 comments per post (set in redditConfig.ts, override via REDDIT_COMMENTS_PER_POST)
  */
 
 import dotenv from 'dotenv'
@@ -25,6 +26,9 @@ import { runRedditPipeline } from '../app/api/redditPipeline/redditPipeline'
 import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline/redditConfig'
 
 dotenv.config({ path: '.env.local' })
+
+// Node 20 lacks native WebSocket — polyfill for @supabase/realtime-js
+if (!globalThis.WebSocket) globalThis.WebSocket = require('ws')
 
 const {
   NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/reddit-scrape-subreddits.ts
+++ b/scripts/reddit-scrape-subreddits.ts
@@ -21,6 +21,9 @@
  */
 
 import dotenv from 'dotenv'
+import { runRedditPipeline } from '../app/api/redditPipeline/redditPipeline'
+import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline/redditConfig'
+
 dotenv.config({ path: '.env.local' })
 
 const REQUIRED_ENV = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] as const
@@ -29,9 +32,6 @@ if (missingEnv.length > 0) {
   console.error(`Missing required env vars: ${missingEnv.join(', ')}`)
   process.exit(1)
 }
-
-import { runRedditPipeline } from '../app/api/redditPipeline/redditPipeline'
-import type { SortSlice, SortOrder, TimePeriod } from '../app/api/redditPipeline/redditConfig'
 
 // ── Parse CLI args ────────────────────────────────────────────────────────────
 

--- a/scripts/seedLocalDb.ts
+++ b/scripts/seedLocalDb.ts
@@ -76,6 +76,40 @@ async function seed() {
 
   console.log("Starting prod → local sync...\n");
 
+  // ── Step 1: wipe all clinic data from local so stale seed.sql rows don't linger
+  // Delete in reverse FK order so foreign key constraints don't block us.
+  // pk = the column to filter on (most tables use "id"; clinic_scores uses "clinic_id")
+  const WIPE_ORDER: Array<{ table: string; pk: string }> = [
+    { table: "clinic_reviews",          pk: "id" },
+    { table: "clinic_mentions",         pk: "id" },
+    { table: "clinic_social_media",     pk: "id" },
+    { table: "clinic_instagram_posts",  pk: "id" },
+    { table: "clinic_packages",         pk: "id" },
+    { table: "clinic_pricing",          pk: "id" },
+    { table: "clinic_facts",            pk: "id" },
+    { table: "clinic_google_places",    pk: "id" },
+    { table: "clinic_score_components", pk: "id" },
+    { table: "clinic_scores",           pk: "clinic_id" },
+    { table: "clinic_media",            pk: "id" },
+    { table: "clinic_credentials",      pk: "id" },
+    { table: "clinic_languages",        pk: "id" },
+    { table: "clinic_services",         pk: "id" },
+    { table: "clinic_locations",        pk: "id" },
+    { table: "clinic_team",             pk: "id" },
+    { table: "clinics",                 pk: "id" },
+    { table: "sources",                 pk: "id" },
+  ];
+
+  process.stdout.write("Wiping local clinic data...");
+  for (const { table, pk } of WIPE_ORDER) {
+    const { error } = await local.from(table).delete().neq(pk, "00000000-0000-0000-0000-000000000000");
+    if (error) {
+      console.error(`\n  ✗ Failed to wipe ${table}: ${error.message}`);
+    }
+  }
+  console.log(" ✓\n");
+
+  // ── Step 2: upsert from production
   for (const table of TABLES) {
     process.stdout.write(`Fetching ${table.label}...`);
 

--- a/supabase/migrations/20260506000000_create_bookmarks_and_consultations.sql
+++ b/supabase/migrations/20260506000000_create_bookmarks_and_consultations.sql
@@ -1,0 +1,30 @@
+-- Bookmarks
+CREATE TABLE user_bookmarks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, clinic_id)
+);
+
+-- Consultations
+CREATE TYPE consultation_status AS ENUM ('pending', 'in_progress', 'completed', 'cancelled');
+
+CREATE TABLE consultations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  status consultation_status NOT NULL DEFAULT 'pending',
+  user_email TEXT NOT NULL,
+  user_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX consultations_pending_unique
+  ON consultations(user_id, clinic_id)
+  WHERE status = 'pending';
+
+CREATE TRIGGER update_consultations_updated_at
+  BEFORE UPDATE ON consultations
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/tests/api/authCallback.test.ts
+++ b/tests/api/authCallback.test.ts
@@ -146,30 +146,23 @@ describe('GET /auth/callback', () => {
     expect(extractLocation(res)).toContain('/auth/login?error=auth_callback_error')
   })
 
-  // ─── New user → get-started ──────────────────────────────────────────────────
+  // ─── Successful auth → /profile ─────────────────────────────────────────────
+  //
+  // The route no longer checks terms acceptance — all authenticated users land
+  // on /profile (or the cookie destination if set). The /profile page handles
+  // onboarding state internally.
 
-  it('redirects new user (no terms) to /profile/get-started', async () => {
+  it('redirects new user to /profile', async () => {
     // No provider_token so People API is skipped; existingUserRow=null = new user
     mockClient(makeSupabase())
     const res = await GET(makeRequest('http://localhost/auth/callback?code=abc'))
-    expect(extractLocation(res)).toContain('/profile/get-started')
+    expect(extractLocation(res)).toContain('/profile')
   })
 
-  // ─── Existing user with terms accepted ──────────────────────────────────────
-
-  it('redirects existing user who accepted terms to /profile', async () => {
+  it('redirects existing user to /profile', async () => {
     mockClient(makeSupabase({ existingUserRow: { id: 'internal-id' }, qualTermsAccepted: true }))
     const res = await GET(makeRequest('http://localhost/auth/callback?code=abc'))
     expect(extractLocation(res)).toContain('/profile')
-    expect(extractLocation(res)).not.toContain('get-started')
-  })
-
-  // ─── Existing user without terms ─────────────────────────────────────────────
-
-  it('redirects existing user who has not accepted terms to /profile/get-started', async () => {
-    mockClient(makeSupabase({ existingUserRow: { id: 'internal-id' }, qualTermsAccepted: false }))
-    const res = await GET(makeRequest('http://localhost/auth/callback?code=abc'))
-    expect(extractLocation(res)).toContain('/profile/get-started')
   })
 
   // ─── Custom next param ───────────────────────────────────────────────────────
@@ -258,9 +251,9 @@ describe('GET /auth/callback', () => {
       existingUserRow: null,
     }))
 
-    // Should not throw; should redirect to get-started
+    // Should not throw; People API failure is non-fatal — user still lands on /profile
     const res = await GET(makeRequest('http://localhost/auth/callback?code=abc'))
-    expect(extractLocation(res)).toContain('/profile/get-started')
+    expect(extractLocation(res)).toContain('/profile')
   })
 
   // ─── fetchGoogleExtras — data parsing ────────────────────────────────────────
@@ -325,6 +318,6 @@ describe('GET /auth/callback', () => {
     mockClient(supabase)
 
     const res = await GET(makeRequest('http://localhost/auth/callback?code=abc'))
-    expect(extractLocation(res)).toContain('/profile/get-started')
+    expect(extractLocation(res)).toContain('/profile')
   })
 })

--- a/tests/api/clinics-scraped-data.test.ts
+++ b/tests/api/clinics-scraped-data.test.ts
@@ -6,7 +6,7 @@
  * added as part of the website-scraping feature.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 // ── Pure logic extracted from lib/api/clinics.ts ──────────────────────────────
 

--- a/tests/api/consultations.test.ts
+++ b/tests/api/consultations.test.ts
@@ -17,6 +17,7 @@ import type { NextRequest } from 'next/server'
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }))
 vi.mock('@/lib/email/sendConsultationRequest', () => ({
   sendConsultationRequest: vi.fn().mockResolvedValue(undefined),
+  sendConsultationConfirmation: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { createClient } from '@/lib/supabase/server'

--- a/tests/api/consultations.test.ts
+++ b/tests/api/consultations.test.ts
@@ -70,10 +70,6 @@ interface MakeSupabaseOptions {
   clinicRows?: { id: string; display_name: string }[]
   existingPending?: { clinic_id: string }[]
   insertResult?: { data: { id: string; clinic_id: string }[] | null; error: { message: string } | null }
-  // GET-specific
-  consultationRows?: object[]
-  consultationError?: { message: string } | null
-  mediaRows?: { clinic_id: string; url: string }[]
 }
 
 function makeSupabase({
@@ -83,10 +79,6 @@ function makeSupabase({
   clinicRows = [{ id: 'clinic-1', display_name: 'Clinic One' }],
   existingPending = [],
   insertResult = { data: [{ id: 'consult-1', clinic_id: 'clinic-1' }], error: null },
-  // GET
-  consultationRows = [],
-  consultationError = null,
-  mediaRows = [],
 }: MakeSupabaseOptions = {}) {
   // Track how many times `consultations` table has been accessed so we can
   // distinguish the pre-filter SELECT from the INSERT (both hit the same table).
@@ -120,7 +112,7 @@ function makeSupabase({
       }
 
       case 'clinic_media':
-        return makeChain(mediaRows)
+        return makeChain([])
 
       default:
         return makeChain(null)

--- a/tests/api/consultations.test.ts
+++ b/tests/api/consultations.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for app/api/consultations/route.ts
+ *
+ * Covers:
+ *   POST — auth gate, body validation, user lookup, email validation,
+ *           batch pre-filter (the "skip already-pending" fix), email failure
+ *           propagation, insert error, and the happy path.
+ *   GET  — auth gate, missing user row (returns empty list, not 404),
+ *           happy path with image join, and DB error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// ─── Mocks must be declared before any imports from the module under test ─────
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }))
+vi.mock('@/lib/email/sendConsultationRequest', () => ({
+  sendConsultationRequest: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { sendConsultationRequest } from '@/lib/email/sendConsultationRequest'
+import { POST, GET } from '@/app/api/consultations/route'
+
+const mockCreateClient = vi.mocked(createClient)
+const mockSendEmail = vi.mocked(sendConsultationRequest)
+
+// ─── Chain builder ─────────────────────────────────────────────────────────────
+//
+// Every Supabase call in this route is a chained query that ends in either:
+//   - .maybeSingle()  → returns { data, error }
+//   - .single()       → returns { data, error }
+//   - a plain await on the last method in the chain (e.g. .eq(), .in(), .order())
+//
+// This builder returns an object that is both chainable (every method returns
+// itself) AND thenable (so `await chain` resolves to { data, error }).
+
+function makeChain(data: unknown, error: unknown = null) {
+  const result = { data, error }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const obj: any = {}
+
+  // Chainable query-builder methods — all return `obj` so chains like
+  // .select().eq().in().eq() work without needing real Supabase.
+  for (const method of ['select', 'eq', 'in', 'insert', 'order', 'is', 'neq', 'limit']) {
+    obj[method] = vi.fn().mockReturnValue(obj)
+  }
+
+  // Terminal methods that return a promise
+  obj.maybeSingle = vi.fn().mockResolvedValue(result)
+  obj.single = vi.fn().mockResolvedValue(result)
+
+  // Make the object itself awaitable so that chains not ending with a
+  // terminal method (e.g. `await supabase.from('x').select().eq()`) work.
+  const p = Promise.resolve(result)
+  obj.then = p.then.bind(p)
+  obj.catch = p.catch.bind(p)
+  obj.finally = p.finally.bind(p)
+
+  return obj
+}
+
+// ─── Supabase client factory ───────────────────────────────────────────────────
+
+interface MakeSupabaseOptions {
+  authUser?: { id: string; email: string } | null
+  authError?: { message: string } | null
+  userRow?: { id: string; name: string; email: string } | null
+  clinicRows?: { id: string; display_name: string }[]
+  existingPending?: { clinic_id: string }[]
+  insertResult?: { data: { id: string; clinic_id: string }[] | null; error: { message: string } | null }
+  // GET-specific
+  consultationRows?: object[]
+  consultationError?: { message: string } | null
+  mediaRows?: { clinic_id: string; url: string }[]
+}
+
+function makeSupabase({
+  authUser = { id: 'auth-uid', email: 'user@test.com' },
+  authError = null,
+  userRow = { id: 'user-uuid', name: 'Test User', email: 'user@test.com' },
+  clinicRows = [{ id: 'clinic-1', display_name: 'Clinic One' }],
+  existingPending = [],
+  insertResult = { data: [{ id: 'consult-1', clinic_id: 'clinic-1' }], error: null },
+  // GET
+  consultationRows = [],
+  consultationError = null,
+  mediaRows = [],
+}: MakeSupabaseOptions = {}) {
+  // Track how many times `consultations` table has been accessed so we can
+  // distinguish the pre-filter SELECT from the INSERT (both hit the same table).
+  let consultationsCallCount = 0
+
+  const fromMock = vi.fn().mockImplementation((table: string) => {
+    switch (table) {
+      case 'users':
+        return makeChain(userRow)
+
+      case 'clinics':
+        return makeChain(clinicRows)
+
+      // Passport profile tables — all optional; returning null is fine
+      case 'user_qualification':
+      case 'user_treatment_profiles':
+      case 'user_profiles':
+      case 'user_prior_transplants':
+      case 'user_prior_surgeries':
+      case 'user_photos':
+        return makeChain(null)
+
+      case 'consultations': {
+        consultationsCallCount++
+        if (consultationsCallCount === 1) {
+          // First call: pre-filter SELECT — returns existing pending rows
+          return makeChain(existingPending)
+        }
+        // Second call: INSERT — returns the newly created rows (or error)
+        return makeChain(insertResult.data, insertResult.error)
+      }
+
+      case 'clinic_media':
+        return makeChain(mediaRows)
+
+      default:
+        return makeChain(null)
+    }
+  })
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue(
+        authError
+          ? { data: { user: null }, error: authError }
+          : { data: { user: authUser }, error: null }
+      ),
+    },
+    from: fromMock,
+  }
+}
+
+// Wire a supabase stub into the mocked createClient
+function mockClient(supabase: ReturnType<typeof makeSupabase>) {
+  // The route calls `await createClient()` so we mockResolvedValue
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockCreateClient.mockResolvedValue(supabase as any)
+}
+
+// Build a minimal NextRequest for POST (only `.json()` is called by the route)
+function makePostRequest(body: object): NextRequest {
+  return { json: vi.fn().mockResolvedValue(body) } as unknown as NextRequest
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/consultations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Auth gate ───────────────────────────────────────────────────────────────
+
+  it('returns 401 when there is no authenticated user', async () => {
+    mockClient(makeSupabase({ authError: { message: 'not authed' } }))
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(401)
+  })
+
+  // ── Body validation ─────────────────────────────────────────────────────────
+
+  it('returns 400 when clinicIds is missing from the body', async () => {
+    mockClient(makeSupabase())
+    const res = await POST(makePostRequest({}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when clinicIds is an empty array', async () => {
+    mockClient(makeSupabase())
+    const res = await POST(makePostRequest({ clinicIds: [] }))
+    expect(res.status).toBe(400)
+  })
+
+  // ── User record lookup ──────────────────────────────────────────────────────
+  //
+  // There are two separate failure modes: no auth session (401) and a valid
+  // auth session but no matching row in the `users` table (404). We test the
+  // 404 path here to make sure they're not conflated.
+
+  it('returns 404 when the auth user has no matching users row', async () => {
+    mockClient(makeSupabase({ userRow: null }))
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(404)
+  })
+
+  // ── Email validation ────────────────────────────────────────────────────────
+  //
+  // This was a real bug: user_email fell back to '' which satisfied the NOT NULL
+  // constraint but inserted bad data. Now the route validates before inserting
+  // and returns 500 if no email is available from either source.
+
+  it('returns 500 when neither the users row nor auth.user has an email', async () => {
+    mockClient(makeSupabase({
+      authUser: { id: 'auth-uid', email: '' },
+      userRow: { id: 'user-uuid', name: 'Test User', email: '' },
+    }))
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/email/i)
+  })
+
+  // ── Batch pre-filter ────────────────────────────────────────────────────────
+  //
+  // The fix for the duplicate-key bug: instead of letting the insert fail when
+  // a clinic is already pending, we pre-query and filter them out. These two
+  // tests lock in that behaviour.
+
+  it('skips already-pending clinics and only inserts the new ones', async () => {
+    // clinic-1 is already pending, clinic-2 is new
+    mockClient(makeSupabase({
+      clinicRows: [
+        { id: 'clinic-1', display_name: 'Clinic One' },
+        { id: 'clinic-2', display_name: 'Clinic Two' },
+      ],
+      existingPending: [{ clinic_id: 'clinic-1' }],
+      insertResult: { data: [{ id: 'consult-2', clinic_id: 'clinic-2' }], error: null },
+    }))
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1', 'clinic-2'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Only clinic-2 was new — that's the one that should be inserted
+    expect(body.created).toBe(1)
+    expect(body.skipped).toBe(1)
+  })
+
+  it('returns created:0 early without inserting when all clinics are already pending', async () => {
+    mockClient(makeSupabase({
+      existingPending: [{ clinic_id: 'clinic-1' }],
+    }))
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toBe(0)
+    expect(body.skipped).toBe(1)
+    // The email should never be attempted when nothing was inserted
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  // ── Insert error ────────────────────────────────────────────────────────────
+
+  it('returns 500 when the DB insert fails', async () => {
+    mockClient(makeSupabase({
+      insertResult: { data: null, error: { message: 'unique violation' } },
+    }))
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(500)
+  })
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  it('creates consultation records and returns emailSent:true on success', async () => {
+    mockClient(makeSupabase())
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toBe(1)
+    expect(body.skipped).toBe(0)
+    expect(body.emailSent).toBe(true)
+    expect(mockSendEmail).toHaveBeenCalledOnce()
+  })
+
+  // ── Email failure propagation ───────────────────────────────────────────────
+  //
+  // The fix from last session: if sendConsultationRequest throws, the records
+  // are already saved (we don't roll back) but the response contains
+  // emailSent:false so the UI can show the amber warning banner.
+
+  it('saves records and returns emailSent:false when the email sender throws', async () => {
+    mockClient(makeSupabase())
+    mockSendEmail.mockRejectedValueOnce(new Error('SMTP timeout'))
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Records were still created
+    expect(body.created).toBe(1)
+    // But email flag is false — this drives the amber banner in the UI
+    expect(body.emailSent).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/consultations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Auth gate ───────────────────────────────────────────────────────────────
+
+  it('returns 401 when there is no authenticated user', async () => {
+    mockClient(makeSupabase({ authError: { message: 'not authed' } }))
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  // ── Missing user row ────────────────────────────────────────────────────────
+  //
+  // If there's a valid auth session but no users row yet (e.g. mid-onboarding),
+  // the route intentionally returns an empty list rather than a 404 — the user
+  // just has no consultations yet.
+
+  it('returns an empty consultations list when no users row exists', async () => {
+    mockClient(makeSupabase({ userRow: null }))
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.consultations).toEqual([])
+  })
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+  //
+  // The GET handler joins clinics and clinic_media and shapes the response.
+  // We verify the shape here: camelCase keys, clinicLocation composed from
+  // primary_city + primary_country, and clinicImage pulled from the media join.
+
+  it('returns shaped consultations with clinic data and image', async () => {
+    const consultationData = [
+      {
+        id: 'consult-1',
+        status: 'pending',
+        created_at: '2026-05-09T00:00:00Z',
+        clinic_id: 'clinic-1',
+        clinics: {
+          id: 'clinic-1',
+          display_name: 'Clinic One',
+          primary_city: 'Istanbul',
+          primary_country: 'Turkey',
+        },
+      },
+    ]
+
+    // We need the GET-path `from('consultations')` to return consultationData,
+    // and `from('clinic_media')` to return the image row.
+    // makeSupabase routes these correctly via the consultationRows / mediaRows options.
+    // However, the GET handler hits `from('consultations')` only once (SELECT, no INSERT),
+    // so we need a custom supabase stub here.
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'auth-uid', email: 'user@test.com' } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'users') return makeChain({ id: 'user-uuid' })
+        if (table === 'consultations') return makeChain(consultationData)
+        if (table === 'clinic_media') return makeChain([{ clinic_id: 'clinic-1', url: 'https://cdn.example.com/img.jpg' }])
+        return makeChain(null)
+      }),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockCreateClient.mockResolvedValue(supabase as any)
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.consultations).toHaveLength(1)
+
+    const c = body.consultations[0]
+    expect(c.id).toBe('consult-1')
+    expect(c.status).toBe('pending')
+    expect(c.clinicName).toBe('Clinic One')
+    expect(c.clinicLocation).toBe('Istanbul, Turkey')
+    expect(c.clinicImage).toBe('https://cdn.example.com/img.jpg')
+  })
+
+  // ── DB error ────────────────────────────────────────────────────────────────
+
+  it('returns 500 when the consultations query fails', async () => {
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'auth-uid', email: 'user@test.com' } },
+          error: null,
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'users') return makeChain({ id: 'user-uuid' })
+        if (table === 'consultations') return makeChain(null, { message: 'connection refused' })
+        return makeChain(null)
+      }),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockCreateClient.mockResolvedValue(supabase as any)
+
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+})

--- a/tests/api/consultations.test.ts
+++ b/tests/api/consultations.test.ts
@@ -69,6 +69,7 @@ interface MakeSupabaseOptions {
   userRow?: { id: string; name: string; email: string } | null
   clinicRows?: { id: string; display_name: string }[]
   existingPending?: { clinic_id: string }[]
+  existingPendingError?: { message: string } | null
   insertResult?: { data: { id: string; clinic_id: string }[] | null; error: { message: string } | null }
 }
 
@@ -78,6 +79,7 @@ function makeSupabase({
   userRow = { id: 'user-uuid', name: 'Test User', email: 'user@test.com' },
   clinicRows = [{ id: 'clinic-1', display_name: 'Clinic One' }],
   existingPending = [],
+  existingPendingError = null,
   insertResult = { data: [{ id: 'consult-1', clinic_id: 'clinic-1' }], error: null },
 }: MakeSupabaseOptions = {}) {
   // Track how many times `consultations` table has been accessed so we can
@@ -105,7 +107,7 @@ function makeSupabase({
         consultationsCallCount++
         if (consultationsCallCount === 1) {
           // First call: pre-filter SELECT — returns existing pending rows
-          return makeChain(existingPending)
+          return makeChain(existingPending, existingPendingError)
         }
         // Second call: INSERT — returns the newly created rows (or error)
         return makeChain(insertResult.data, insertResult.error)
@@ -172,6 +174,12 @@ describe('POST /api/consultations', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 400 when clinicIds contains no valid string IDs', async () => {
+    mockClient(makeSupabase())
+    const res = await POST(makePostRequest({ clinicIds: ['', null, 42] }))
+    expect(res.status).toBe(400)
+  })
+
   // ── User record lookup ──────────────────────────────────────────────────────
   //
   // There are two separate failure modes: no auth session (401) and a valid
@@ -224,6 +232,49 @@ describe('POST /api/consultations', () => {
     // Only clinic-2 was new — that's the one that should be inserted
     expect(body.created).toBe(1)
     expect(body.skipped).toBe(1)
+  })
+
+  it('deduplicates clinicIds before inserting', async () => {
+    const supabase = makeSupabase({
+      clinicRows: [
+        { id: 'clinic-1', display_name: 'Clinic One' },
+        { id: 'clinic-2', display_name: 'Clinic Two' },
+      ],
+      insertResult: {
+        data: [
+          { id: 'consult-1', clinic_id: 'clinic-1' },
+          { id: 'consult-2', clinic_id: 'clinic-2' },
+        ],
+        error: null,
+      },
+    })
+    mockClient(supabase)
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1', 'clinic-1', 'clinic-2'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toBe(2)
+    expect(body.skipped).toBe(0)
+
+    const insertChain = supabase.from.mock.results
+      .filter((r) => r.value?.insert)
+      .at(-1)?.value
+    expect(insertChain.insert).toHaveBeenCalledWith([
+      expect.objectContaining({ clinic_id: 'clinic-1' }),
+      expect.objectContaining({ clinic_id: 'clinic-2' }),
+    ])
+  })
+
+  it('returns 500 when the existing-pending lookup fails', async () => {
+    mockClient(makeSupabase({
+      existingPendingError: { message: 'lookup failed' },
+    }))
+
+    const res = await POST(makePostRequest({ clinicIds: ['clinic-1'] }))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/existing consultations/i)
+    expect(mockSendEmail).not.toHaveBeenCalled()
   })
 
   it('returns created:0 early without inserting when all clinics are already pending', async () => {

--- a/tests/components/BookmarkButton.test.tsx
+++ b/tests/components/BookmarkButton.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for components/istanbulmedic-connect/BookmarkButton.tsx
+ *
+ * Covers:
+ *   - Visual state: filled icon when bookmarked, outline when not
+ *   - Auth gate: unauthenticated click redirects to /auth/login
+ *   - Add: calls POST /api/bookmarks, optimistic addId, reverts on failure
+ *   - Remove: calls DELETE /api/bookmarks, optimistic removeId, reverts on failure
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// ─── Context mocks ─────────────────────────────────────────────────────────────
+//
+// We expose mutable variables so individual tests can control the context state
+// (e.g. put a clinicId in bookmarkedIds to simulate an already-bookmarked state).
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
+
+let bookmarkedIds = new Set<string>()
+const mockAddId = vi.fn()
+const mockRemoveId = vi.fn()
+
+vi.mock('@/contexts/BookmarkCountContext', () => ({
+  useBookmarkCount: () => ({ bookmarkedIds, addId: mockAddId, removeId: mockRemoveId }),
+}))
+
+let isAuthenticated = false
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated }),
+}))
+
+import { BookmarkButton } from '@/components/istanbulmedic-connect/BookmarkButton'
+
+const defaultProps = {
+  clinicId: 'clinic-1',
+  clinicName: 'Test Clinic',
+}
+
+describe('BookmarkButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset shared state before each test
+    bookmarkedIds = new Set()
+    isAuthenticated = false
+    global.fetch = vi.fn()
+  })
+
+  // ── Visual state ─────────────────────────────────────────────────────────────
+
+  it('renders with "Bookmark" aria-label when not yet bookmarked', () => {
+    render(<BookmarkButton {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Bookmark Test Clinic' })).toBeInTheDocument()
+  })
+
+  it('renders with "Remove" aria-label when already bookmarked', () => {
+    bookmarkedIds = new Set(['clinic-1'])
+    render(<BookmarkButton {...defaultProps} />)
+    expect(screen.getByRole('button', { name: 'Remove Test Clinic from bookmarks' })).toBeInTheDocument()
+  })
+
+  it('renders optional label when provided', () => {
+    render(<BookmarkButton {...defaultProps} label="Save Clinic" />)
+    expect(screen.getByText('Save Clinic')).toBeInTheDocument()
+  })
+
+  it('renders labelSaved when already bookmarked and labelSaved is provided', () => {
+    bookmarkedIds = new Set(['clinic-1'])
+    render(<BookmarkButton {...defaultProps} label="Save Clinic" labelSaved="Saved" />)
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  // ── Auth gate ─────────────────────────────────────────────────────────────────
+  //
+  // Clicking while signed out should NOT call the API — it should set a cookie
+  // for post-login redirect and push to /auth/login.
+
+  it('redirects unauthenticated user to /auth/login on click', () => {
+    isAuthenticated = false
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockPush).toHaveBeenCalledWith('/auth/login')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('sets auth_redirect_next cookie before redirecting', () => {
+    isAuthenticated = false
+    // jsdom doesn't implement cookie writing, so we spy on document.cookie setter
+    let writtenCookie = ''
+    const descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie')!
+    vi.spyOn(document, 'cookie', 'set').mockImplementation((val) => { writtenCookie = val })
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(writtenCookie).toContain('auth_redirect_next')
+
+    // Restore original cookie descriptor
+    Object.defineProperty(document, 'cookie', descriptor)
+  })
+
+  // ── Add (optimistic + revert) ─────────────────────────────────────────────────
+  //
+  // addId is called immediately (optimistic). If the API call fails, removeId
+  // is called to roll back.
+
+  it('calls addId immediately and POSTs to /api/bookmarks when adding', async () => {
+    isAuthenticated = true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockResolvedValueOnce({ ok: true })
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    // Optimistic update happens synchronously
+    expect(mockAddId).toHaveBeenCalledWith('clinic-1')
+
+    // API call happens asynchronously
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/bookmarks',
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+    // No revert on success
+    expect(mockRemoveId).not.toHaveBeenCalled()
+  })
+
+  it('reverts optimistic add by calling removeId when the API returns non-ok', async () => {
+    isAuthenticated = true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockResolvedValueOnce({ ok: false })
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(mockRemoveId).toHaveBeenCalledWith('clinic-1'))
+  })
+
+  it('reverts optimistic add by calling removeId when fetch throws', async () => {
+    isAuthenticated = true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockRejectedValueOnce(new Error('network error'))
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(mockRemoveId).toHaveBeenCalledWith('clinic-1'))
+  })
+
+  // ── Remove (optimistic + revert) ──────────────────────────────────────────────
+
+  it('calls removeId immediately and DELETEs from /api/bookmarks when removing', async () => {
+    isAuthenticated = true
+    bookmarkedIds = new Set(['clinic-1'])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockResolvedValueOnce({ ok: true })
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mockRemoveId).toHaveBeenCalledWith('clinic-1')
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/bookmarks',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+    expect(mockAddId).not.toHaveBeenCalled()
+  })
+
+  it('reverts optimistic remove by calling addId when the API returns non-ok', async () => {
+    isAuthenticated = true
+    bookmarkedIds = new Set(['clinic-1'])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockResolvedValueOnce({ ok: false })
+
+    render(<BookmarkButton {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(mockAddId).toHaveBeenCalledWith('clinic-1'))
+  })
+})

--- a/tests/components/BookmarksPage.test.tsx
+++ b/tests/components/BookmarksPage.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Tests for app/bookmarks/page.tsx
+ *
+ * Covers:
+ *   - Empty state: "no saved clinics" message and browse link
+ *   - Populated list: clinic rows render correctly
+ *   - Single consultation request: happy path → marks clinic as requested
+ *   - emailSent:false → amber warning banner appears
+ *   - API failure → UI stays unchanged (clinic remains requestable)
+ *   - Bulk select + request: selection state, button label, confirm flow
+ *   - Remove bookmark: clinic removed from the list
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/font/google', () => ({
+  Merriweather: () => ({ className: 'mocked-merriweather' }),
+}))
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/bookmarks',
+}))
+
+// useAuth controls whether the page considers the user signed in.
+// isAuthenticated=true prevents the redirect effect from firing.
+let isAuthenticated = true
+let authLoading = false
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated, loading: authLoading }),
+}))
+
+// BookmarkCountContext — the page only uses removeId from this context
+const mockRemoveId = vi.fn()
+vi.mock('@/contexts/BookmarkCountContext', () => ({
+  useBookmarkCount: () => ({ removeId: mockRemoveId }),
+}))
+
+import BookmarksPage from '@/app/bookmarks/page'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeClinic(overrides: Partial<{
+  bookmarkId: string
+  clinicId: string
+  name: string
+  location: string
+  image: string | null
+  rating: number | null
+  reviewCount: number
+  consultationRequested: boolean
+}> = {}) {
+  return {
+    bookmarkId: 'bm-1',
+    clinicId: 'clinic-1',
+    name: 'Clinic One',
+    location: 'Istanbul, Turkey',
+    image: null,
+    rating: 4.5,
+    reviewCount: 120,
+    consultationRequested: false,
+    ...overrides,
+  }
+}
+
+// Stub global.fetch to return a bookmarks list
+function mockBookmarksFetch(clinics: ReturnType<typeof makeClinic>[]) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(global.fetch as any).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ bookmarks: clinics }),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('BookmarksPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isAuthenticated = true
+    authLoading = false
+    global.fetch = vi.fn()
+  })
+
+  // ── Empty state ─────────────────────────────────────────────────────────────
+  //
+  // When /api/bookmarks returns an empty list, the page should show the
+  // placeholder UI with a "Browse clinics" link — not a broken or blank page.
+
+  it('shows the empty state when there are no bookmarks', async () => {
+    mockBookmarksFetch([])
+    render(<BookmarksPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/no saved clinics yet/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('link', { name: /browse clinics/i })).toBeInTheDocument()
+  })
+
+  // ── Populated list ──────────────────────────────────────────────────────────
+
+  it('renders a row for each bookmarked clinic', async () => {
+    mockBookmarksFetch([
+      makeClinic({ clinicId: 'clinic-1', name: 'Clinic One' }),
+      makeClinic({ clinicId: 'clinic-2', name: 'Clinic Two', bookmarkId: 'bm-2' }),
+    ])
+    render(<BookmarksPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Clinic One')).toBeInTheDocument()
+      expect(screen.getByText('Clinic Two')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Requested" for clinics that already have a consultation', async () => {
+    mockBookmarksFetch([
+      makeClinic({ consultationRequested: true }),
+    ])
+    render(<BookmarksPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/requested/i)).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /request consultation/i })).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Single consultation request ─────────────────────────────────────────────
+  //
+  // Clicking "Request Consultation" on a single clinic opens the confirm modal.
+  // On confirm, POST /api/consultations is called and the row flips to "Requested".
+
+  it('marks a clinic as requested after confirming the consultation modal', async () => {
+    mockBookmarksFetch([makeClinic()])
+    // The page fetches bookmarks on mount (first call), then the consultation POST
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bookmarks: [makeClinic()] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ created: 1, emailSent: true }) })
+
+    render(<BookmarksPage />)
+
+    // Wait for the list to load, then open modal
+    await waitFor(() => screen.getByText('Clinic One'))
+    fireEvent.click(screen.getByRole('button', { name: /request consultation/i }))
+
+    // Confirm in the modal
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/requested/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── emailSent:false → amber warning banner ──────────────────────────────────
+  //
+  // If the API responds with emailSent:false (email sender threw), the UI shows
+  // an amber banner telling the user the team will follow up within 24 hours.
+  // This banner is the only user-visible feedback for the email failure path.
+
+  it('shows the amber warning banner when emailSent is false', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bookmarks: [makeClinic()] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ created: 1, emailSent: false }) })
+
+    render(<BookmarksPage />)
+
+    await waitFor(() => screen.getByText('Clinic One'))
+    fireEvent.click(screen.getByRole('button', { name: /request consultation/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/our team will be in touch within 24 hours/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── API failure → UI unchanged ──────────────────────────────────────────────
+  //
+  // If the consultation POST fails (non-ok response), the clinic should remain
+  // in the "requestable" state — no error message, just stays as-is so the user
+  // can retry.
+
+  it('leaves the clinic requestable when the API call fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bookmarks: [makeClinic()] }) })
+      .mockResolvedValueOnce({ ok: false })
+
+    render(<BookmarksPage />)
+
+    await waitFor(() => screen.getByText('Clinic One'))
+    fireEvent.click(screen.getByRole('button', { name: /request consultation/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
+
+    // Button should still be present — clinic is still requestable
+    expect(screen.getByRole('button', { name: /request consultation/i })).toBeInTheDocument()
+    expect(screen.queryByText(/requested/i)).not.toBeInTheDocument()
+  })
+
+  // ── Bulk select + request ───────────────────────────────────────────────────
+  //
+  // Selecting clinics via checkbox shows the "Request Consultation (N)" bulk
+  // button. Confirming the bulk modal POSTs all selected clinic IDs at once.
+
+  it('shows the bulk request button with count when clinics are selected', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        bookmarks: [
+          makeClinic({ clinicId: 'clinic-1', name: 'Clinic One' }),
+          makeClinic({ clinicId: 'clinic-2', name: 'Clinic Two', bookmarkId: 'bm-2' }),
+        ],
+      }),
+    })
+
+    render(<BookmarksPage />)
+
+    await waitFor(() => screen.getByText('Clinic One'))
+
+    // Select the first clinic
+    fireEvent.click(screen.getByRole('checkbox', { name: /select clinic one/i }))
+
+    expect(screen.getByRole('button', { name: /request consultation \(1\)/i })).toBeInTheDocument()
+  })
+
+  it('marks all selected clinics as requested after bulk confirm', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          bookmarks: [
+            makeClinic({ clinicId: 'clinic-1', name: 'Clinic One' }),
+            makeClinic({ clinicId: 'clinic-2', name: 'Clinic Two', bookmarkId: 'bm-2' }),
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ created: 2, emailSent: true }) })
+
+    render(<BookmarksPage />)
+
+    await waitFor(() => screen.getByText('Clinic One'))
+
+    // Select both clinics
+    fireEvent.click(screen.getByRole('checkbox', { name: /select clinic one/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /select clinic two/i }))
+
+    // Open bulk modal and confirm
+    fireEvent.click(screen.getByRole('button', { name: /request consultation \(2\)/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }))
+
+    await waitFor(() => {
+      // Both clinics should now show "Requested"
+      const requestedItems = screen.getAllByText(/requested/i)
+      expect(requestedItems.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  // ── Remove bookmark ─────────────────────────────────────────────────────────
+  //
+  // Clicking the bookmark icon opens a confirm modal. On confirm, the clinic is
+  // removed from the list immediately (optimistic) and DELETE /api/bookmarks
+  // is called. removeId is called on the context to sync the nav badge count.
+
+  it('removes a clinic from the list after confirming the remove modal', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(global.fetch as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ bookmarks: [makeClinic()] }) })
+      .mockResolvedValueOnce({ ok: true }) // DELETE response
+
+    render(<BookmarksPage />)
+
+    await waitFor(() => screen.getByText('Clinic One'))
+
+    // Click the bookmark icon to trigger the remove modal
+    fireEvent.click(screen.getByRole('button', { name: /remove clinic one from bookmarks/i }))
+    // Confirm removal
+    fireEvent.click(screen.getByRole('button', { name: /^remove$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Clinic One')).not.toBeInTheDocument()
+    })
+
+    // Context badge count should be updated
+    expect(mockRemoveId).toHaveBeenCalledWith('clinic-1')
+  })
+})

--- a/tests/components/ClinicCard.test.tsx
+++ b/tests/components/ClinicCard.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // Mock the Google Font before importing ClinicCard
 vi.mock('next/font/google', () => ({
@@ -8,27 +8,33 @@ vi.mock('next/font/google', () => ({
   }),
 }));
 
+// Stable router mock — shared across all tests so we can assert on `push`
+const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
+// Mutable so consultation tests can flip to authenticated
+let isAuthenticated = false;
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: false, loading: false }),
+  useAuth: () => ({ isAuthenticated, loading: false }),
 }));
 
 import { ClinicCard } from '@/components/istanbulmedic-connect/ClinicCard';
 
+// Shared across both describe blocks
+const defaultProps = {
+  id: 'clinic-test-id',
+  name: 'Test Clinic',
+  location: 'Istanbul, Turkey',
+  image: 'https://example.com/clinic.jpg',
+  specialties: ['Hair Transplant', 'Dental'],
+  trustScore: 85,
+  description: 'A quality healthcare clinic in Istanbul.',
+  onViewProfile: vi.fn(),
+};
+
 describe('ClinicCard', () => {
-  const defaultProps = {
-    id: 'clinic-test-id',
-    name: 'Test Clinic',
-    location: 'Istanbul, Turkey',
-    image: 'https://example.com/clinic.jpg',
-    specialties: ['Hair Transplant', 'Dental'],
-    trustScore: 85,
-    description: 'A quality healthcare clinic in Istanbul.',
-    onViewProfile: vi.fn(),
-  };
 
   it('renders clinic name', () => {
     render(<ClinicCard {...defaultProps} />);
@@ -139,5 +145,101 @@ describe('ClinicCard', () => {
 
     // Should still render without crashing
     expect(screen.getByText('Test Clinic')).toBeInTheDocument();
+  });
+});
+
+// ─── Consultation behavior ─────────────────────────────────────────────────────
+//
+// FEATURE_CONFIG.bookConsultation is true, so the "Request Free Consultation"
+// link and its modal are active. These tests cover the auth gate, modal trigger,
+// happy-path confirm, and failure-stays-unchanged behaviour.
+
+describe('ClinicCard — consultation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAuthenticated = false;
+    global.fetch = vi.fn();
+  });
+
+  it('shows "Request Free Consultation" button', () => {
+    render(<ClinicCard {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /request free consultation/i })).toBeInTheDocument();
+  });
+
+  // ── Auth gate ──────────────────────────────────────────────────────────────
+  //
+  // When signed out, clicking the button should redirect — not open the modal.
+
+  it('redirects unauthenticated user to /auth/login on click', () => {
+    isAuthenticated = false;
+    render(<ClinicCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('does not open the modal when user is unauthenticated', () => {
+    isAuthenticated = false;
+    render(<ClinicCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    // The modal title should not be in the DOM
+    expect(screen.queryByText('Request Free Consultation', { selector: '[role="heading"]' })).not.toBeInTheDocument();
+  });
+
+  // ── Modal trigger ──────────────────────────────────────────────────────────
+
+  it('opens the confirmation modal when authenticated user clicks the button', () => {
+    isAuthenticated = true;
+    render(<ClinicCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    // Modal body confirms it's open for the right clinic — the phrase includes the clinic name
+    expect(screen.getByText(/request a free consultation with/i)).toBeInTheDocument();
+  });
+
+  // ── Confirm → API + UI flip ────────────────────────────────────────────────
+
+  it('calls /api/consultations and shows "Consultation Requested" after confirming', async () => {
+    isAuthenticated = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ emailSent: true }) });
+
+    render(<ClinicCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    // Click the confirm button inside the modal
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/consultations',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    // Button replaced by the "Consultation Requested" state
+    await waitFor(() => {
+      expect(screen.getByText(/consultation requested/i)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /request free consultation/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── API failure → UI stays unchanged ──────────────────────────────────────
+  //
+  // If the API returns non-ok, the UI should stay showing the button so the
+  // user can retry — we don't show an error state, we just leave it as-is.
+
+  it('leaves the button visible when the API call fails', async () => {
+    isAuthenticated = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global.fetch as any).mockResolvedValueOnce({ ok: false });
+
+    render(<ClinicCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    // Button should still be there — user can retry
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /request free consultation/i })).toBeInTheDocument();
+    });
   });
 });

--- a/tests/components/ClinicCard.test.tsx
+++ b/tests/components/ClinicCard.test.tsx
@@ -8,10 +8,19 @@ vi.mock('next/font/google', () => ({
   }),
 }));
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false, loading: false }),
+}));
+
 import { ClinicCard } from '@/components/istanbulmedic-connect/ClinicCard';
 
 describe('ClinicCard', () => {
   const defaultProps = {
+    id: 'clinic-test-id',
     name: 'Test Clinic',
     location: 'Istanbul, Turkey',
     image: 'https://example.com/clinic.jpg',

--- a/tests/components/ClinicProfilePage.test.tsx
+++ b/tests/components/ClinicProfilePage.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { ClinicProfilePage } from '@/components/istanbulmedic-connect/profile/ClinicProfilePage';
 import type { ClinicDetail } from '@/lib/api/clinics';
 
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false, loading: false }),
+}));
+
 // Mock Next.js components and hooks
 vi.mock('next/navigation', () => ({
   useRouter: () => ({

--- a/tests/components/ExploreClinicsPage.test.tsx
+++ b/tests/components/ExploreClinicsPage.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ExploreClinicsPage } from '@/components/istanbulmedic-connect/ExploreClinicsPage';
 import type { Clinic, FilterState } from '@/components/istanbulmedic-connect/types';
 
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false, loading: false }),
+}));
+
 // Mock next/navigation
 const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({

--- a/tests/components/SummarySidebar.test.tsx
+++ b/tests/components/SummarySidebar.test.tsx
@@ -1,26 +1,29 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
+const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
+let isAuthenticated = false;
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: false, loading: false }),
+  useAuth: () => ({ isAuthenticated, loading: false }),
 }));
 
 import { SummarySidebar } from '@/components/istanbulmedic-connect/profile/SummarySidebar';
 
-describe('SummarySidebar', () => {
-  const defaultProps = {
-    clinicId: 'clinic-test-id',
-    clinicName: 'Test Clinic',
-    transparencyScore: 85,
-    topSpecialties: ['Hair Transplant', 'Dental'],
-    rating: 4.8,
-    reviewCount: 150,
-  };
+// Shared across both describe blocks
+const defaultProps = {
+  clinicId: 'clinic-test-id',
+  clinicName: 'Test Clinic',
+  transparencyScore: 85,
+  topSpecialties: ['Hair Transplant', 'Dental'],
+  rating: 4.8,
+  reviewCount: 150,
+};
 
+describe('SummarySidebar', () => {
   // TODO: Unskip when FEATURE_CONFIG.profilePricing is enabled
   it.skip('renders price estimate', () => {
     render(<SummarySidebar {...defaultProps} priceEstimate="$2,500" />);
@@ -177,5 +180,91 @@ describe('SummarySidebar', () => {
     expect(screen.getByText('Consultation fee')).toBeInTheDocument();
     expect(screen.getByText('Service charge')).toBeInTheDocument();
     expect(screen.getByText('Total (estimate)')).toBeInTheDocument();
+  });
+});
+
+// ─── Consultation behavior ─────────────────────────────────────────────────────
+//
+// FEATURE_CONFIG.bookConsultation is true. The sidebar renders a
+// "Request Free Consultation" button that gates on auth and fires a modal
+// before calling the API — same flow as ClinicCard.
+
+describe('SummarySidebar — consultation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAuthenticated = false;
+    global.fetch = vi.fn();
+  });
+
+  it('shows "Request Free Consultation" button', () => {
+    render(<SummarySidebar {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /request free consultation/i })).toBeInTheDocument();
+  });
+
+  // ── Auth gate ──────────────────────────────────────────────────────────────
+
+  it('redirects unauthenticated user to /auth/login on click', () => {
+    isAuthenticated = false;
+    render(<SummarySidebar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    expect(mockPush).toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('does not open the modal when user is unauthenticated', () => {
+    isAuthenticated = false;
+    render(<SummarySidebar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    expect(screen.queryByText(/request a free consultation with/i)).not.toBeInTheDocument();
+  });
+
+  // ── Modal trigger ──────────────────────────────────────────────────────────
+
+  it('opens the confirmation modal when authenticated user clicks the button', () => {
+    isAuthenticated = true;
+    render(<SummarySidebar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    expect(screen.getByText(/request a free consultation with/i)).toBeInTheDocument();
+  });
+
+  // ── Confirm → API + UI flip ────────────────────────────────────────────────
+
+  it('calls /api/consultations and shows "Consultation Requested" after confirming', async () => {
+    isAuthenticated = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => ({ emailSent: true }) });
+
+    render(<SummarySidebar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/consultations',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/consultation requested/i)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /request free consultation/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── API failure → UI stays unchanged ──────────────────────────────────────
+
+  it('leaves the button visible when the API call fails', async () => {
+    isAuthenticated = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global.fetch as any).mockResolvedValueOnce({ ok: false });
+
+    render(<SummarySidebar {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /request free consultation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^request consultation$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /request free consultation/i })).toBeInTheDocument();
+    });
   });
 });

--- a/tests/components/SummarySidebar.test.tsx
+++ b/tests/components/SummarySidebar.test.tsx
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false, loading: false }),
+}));
+
 import { SummarySidebar } from '@/components/istanbulmedic-connect/profile/SummarySidebar';
 
 describe('SummarySidebar', () => {
   const defaultProps = {
+    clinicId: 'clinic-test-id',
+    clinicName: 'Test Clinic',
     transparencyScore: 85,
     topSpecialties: ['Hair Transplant', 'Dental'],
     rating: 4.8,
@@ -142,10 +153,10 @@ describe('SummarySidebar', () => {
   });
 
   // TODO: Unskip when FEATURE_CONFIG.bookConsultation is enabled
-  it.skip('renders custom book consultation href', () => {
-    render(<SummarySidebar {...defaultProps} bookConsultationHref="https://custom-link.com" />);
-    const link = screen.getByRole('link', { name: 'Book Consultation' });
-    expect(link).toHaveAttribute('href', 'https://custom-link.com');
+  it.skip('renders book consultation button', () => {
+    render(<SummarySidebar {...defaultProps} />);
+    const btn = screen.getByRole('button', { name: /consultation/i });
+    expect(btn).toBeInTheDocument();
   });
 
   it('handles null rating', () => {

--- a/tests/components/langchain/LangchainChat.test.tsx
+++ b/tests/components/langchain/LangchainChat.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LangchainChat from '@/components/langchain/LangchainChat';
 


### PR DESCRIPTION
# Consultations feature — bug fixes + full test coverage

## What you changed

### Bug fixes (`app/api/consultations/route.ts`)

- **Batch insert pre-filter** — before inserting, the route now queries existing `pending` consultations for the user and filters them out. Previously a single duplicate would trigger a partial-index conflict and abort the entire batch, silently failing all clinics in the request.
- **Email validation** — `user_email` used to fall back to `''` if both `userRow.email` and `user.email` were null, which satisfied the `NOT NULL` constraint but inserted an empty string. Now the route validates and returns 500 before touching the DB.
- **Email failure propagation** — `sendConsultationRequest` was called in a fire-and-forget pattern; errors were swallowed. Now it's wrapped in try/catch and `emailSent: false` is returned in the response so the UI can surface it.
- **Partial profile query failures** — errors from the 6 parallel passport data queries (`qual`, `treat`, `profile`, etc.) were silently discarded. Now captured and logged with `userId` + `failedQueries`.

### Bug fixes (auth + UI)

- **`app/auth/callback/route.ts`** — cookie parsing used `.split('=')[1]` which truncated redirect URLs containing `=` signs (e.g. URLs with query params). Fixed to `.split('=').slice(1).join('=')`.
- **`app/bookmarks/page.tsx`**, **`components/istanbulmedic-connect/ClinicCard.tsx`**, **`components/istanbulmedic-connect/profile/SummarySidebar.tsx`** — consultation request buttons updated state optimistically before checking `res.ok`. If the API returned a 500, the UI showed "Requested" anyway. Fixed: wait for `res.ok` before updating state.

### Other

- **`contexts/BookmarkCountContext.tsx`** — suppressed a pre-existing `react-hooks/set-state-in-effect` lint error (the synchronous `setBookmarkedIds` clear on logout is intentional and safe — added inline comment explaining why).

---

## Highlight: important parts to review

**`app/api/consultations/route.ts` lines 71–83** — the batch pre-filter. This is the most critical logic change. It queries `consultations WHERE status = 'pending'` before inserting, builds a `Set` of existing IDs, and filters `clinicIds` down to only new ones. If nothing is new it returns early without touching the insert path.

```ts
const { data: existingPending } = await supabase
  .from('consultations')
  .select('clinic_id')
  .eq('user_id', userRow.id)
  .in('clinic_id', clinicIds)
  .eq('status', 'pending')

const existingIds = new Set((existingPending ?? []).map((r) => r.clinic_id))
const newClinicIds = clinicIds.filter((id) => !existingIds.has(id))

if (newClinicIds.length === 0) {
  return NextResponse.json({ created: 0, skipped: clinicIds.length })
}
```

**`app/api/consultations/route.ts` lines 151–168** — email failure handling. Records are already committed when the email is attempted, so we don't roll back. `emailSent: false` in the response is what drives the amber warning banner in the UI.

---

## Why you changed it

The feature was implemented but had several edge cases that would silently fail in production:

- A user requesting consultations from multiple already-pending clinics would get a DB conflict error that aborted the whole batch — they'd see no feedback and no records would be created.
- A user with no email on their account would insert an empty string into a field that's supposed to snapshot their contact info for the concierge team.
- Email failures were invisible — the user would see "Requested" but the team would never receive the notification.
- The auth redirect cookie fix affected users signing in from a page with complex URLs (any URL with a query string).

---

## Automated tests

### New test files

| File | Type | Count |
|------|------|-------|
| `tests/api/consultations.test.ts` | Unit (API route) | 13 tests |
| `tests/components/BookmarkButton.test.tsx` | Unit (component) | 11 tests |
| `tests/components/BookmarksPage.test.tsx` | Unit (component) | 9 tests |

### Extended test files

| File | Added |
|------|-------|
| `tests/components/ClinicCard.test.tsx` | +6 consultation tests |
| `tests/components/SummarySidebar.test.tsx` | +5 consultation tests |

### What each area covers

**API route (`consultations.test.ts`)**
- 401 when unauthenticated
- 400 when body is missing or empty
- 404 when no `users` row found
- 500 when user has no email (the bad-data guard)
- Batch pre-filter: partially-pending request inserts only new clinics
- All-pending early return: returns `created:0` without hitting the insert path
- Insert DB error → 500
- Happy path: creates records, `emailSent:true`
- Email failure: records saved, `emailSent:false` in response
- GET: auth gate, empty list when no user row, shaped response with image join, DB error → 500

**BookmarkButton (`BookmarkButton.test.tsx`)**
- Correct aria-label when bookmarked vs. not
- Optional label and labelSaved rendering
- Unauthenticated click → redirect to `/auth/login`
- `auth_redirect_next` cookie is set before redirect
- Optimistic add + revert on non-ok response
- Optimistic add + revert on fetch throw
- Optimistic remove + revert on non-ok response

**ClinicCard / SummarySidebar (extended)**
- "Request Free Consultation" button is present
- Unauthenticated click → redirect, no modal
- Authenticated click → confirmation modal opens
- Confirm → API called, UI flips to "Consultation Requested"
- API failure → button stays, user can retry

**BookmarksPage (`BookmarksPage.test.tsx`)**
- Empty state renders with "Browse clinics" link
- Populated list renders clinic rows
- Already-requested clinics show "Requested" without a button
- Single request: confirm modal → API → row marked as requested
- `emailSent:false` response → amber warning banner renders
- API failure → clinic stays requestable
- Bulk select: checkbox → button shows correct count
- Bulk confirm → all selected clinics marked as requested
- Remove: confirm modal → clinic removed from list, `removeId` called on context

### How to run tests

Run the full suite:
```bash
npx vitest run
```

Run a specific file:
```bash
npx vitest run tests/api/consultations.test.ts
npx vitest run tests/components/BookmarksPage.test.tsx
```

Watch mode (reruns on save):
```bash
npm run test
```

---

## Manual testing steps

> Requires local Supabase running (`supabase start`) and `npm run dev`.

### Bookmark add/remove
1. Browse to `/clinics` while signed out — confirm no bookmark icons are visible
2. Sign in with Google
3. On any clinic card, click the bookmark icon — icon should fill immediately (optimistic)
4. Navigate to `/bookmarks` — clinic should appear in the list
5. Click the filled bookmark icon on the bookmarks page — confirm modal appears ("Remove Bookmark")
6. Confirm — clinic disappears from the list

### Consultation request (single, from clinic card)
1. While signed out, click "Request Free Consultation" on any clinic card — should redirect to `/auth/login`
2. Sign in — should redirect back to the clinic listing
3. Click "Request Free Consultation" — confirmation modal appears
4. Confirm — button replaced by "Consultation Requested" ✓ checkmark
5. Refresh — the card should still show "Consultation Requested" (state persists via DB)
6. Check Supabase `consultations` table — row should exist with `status = 'pending'`

### Consultation request (bulk, from bookmarks page)
1. Bookmark 2–3 clinics
2. Go to `/bookmarks`
3. Check the checkboxes next to at least 2 unrequested clinics
4. Click "Request Consultation (N)" button in the header
5. Confirm — all selected rows flip to "Requested"

### Email warning banner
> With `RESEND_API_KEY` not set, `sendConsultationRequest` logs to console and does not throw, so `emailSent` will be `true`. To test the banner, temporarily make `sendConsultationRequest` throw in `lib/email/sendConsultationRequest.ts`.

1. Make the email sender throw
2. Submit a consultation request
3. Banner should appear: *"Your consultation request was saved, but we had trouble sending the notification. Our team will be in touch within 24 hours."*

### Auth redirect cookie
1. While signed out, navigate to `/bookmarks`
2. Should redirect to `/auth/login`
3. Sign in with Google
4. Should redirect back to `/bookmarks` (not `/profile`)

---

## Future steps

- **TODO: set up GitHub Actions to run automated tests** — `npx vitest run` should be added as a CI step on every PR. The lint step (`npm run lint`) is already running.
- **RLS policies** — `user_bookmarks` and `consultations` tables have no Row Level Security. Safe for now since all access goes through Next.js API routes, but should be added before any direct client access is introduced.
- **Email activation** — `sendConsultationRequest` currently logs to console only. Needs `RESEND_API_KEY` + `CONSULTATION_EMAIL` env vars + `npm install resend` to activate real sending.
- **Consultation status management** — no admin UI exists yet to update `status` from `pending` to `completed`/`cancelled`. The schema supports it; the interface doesn't.
