### PR TITLE
Improve mobile clinic comparison layout

### DIFF
--- a/components/istanbulmedic-connect/comparison/CompareClinicPage.tsx
+++ b/components/istanbulmedic-connect/comparison/CompareClinicPage.tsx
@@ -301,6 +301,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
           <div className="flex w-full rounded-lg border border-border/60 bg-muted/30 p-1 md:hidden" aria-label="Choose comparison clinic">
             <button
               type="button"
+              aria-label="Switch to Clinic A"
               aria-pressed={mobilePane === "left"}
               onClick={() => setMobilePane("left")}
               className={cn(
@@ -317,6 +318,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
             </button>
             <button
               type="button"
+              aria-label="Switch to Clinic B"
               aria-pressed={mobilePane === "right"}
               onClick={() => setMobilePane("right")}
               className={cn(
@@ -350,7 +352,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
             </div>
             {(leftId || rightId) && (
               <button
-                onClick={() => { setLeftId(null); setRightId(null) }}
+                onClick={() => { setLeftId(null); setRightId(null); setMobilePane("left") }}
                 className="text-sm text-[var(--im-color-primary)] hover:underline underline-offset-2 whitespace-nowrap"
               >
                 Clear selection
@@ -368,7 +370,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
           label="Clinic A"
           headerBg="bg-[var(--im-color-primary)]"
           accentClass="text-[var(--im-color-primary)]"
-          className={cn(mobilePane === "left" ? "flex" : "hidden md:flex")}
+          className={mobilePane === "left" ? "flex" : "hidden md:flex"}
           clinics={sortedClinics}
           selectedId={leftId}
           disabledId={rightId}
@@ -380,7 +382,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
           label="Clinic B"
           headerBg="bg-[var(--im-color-secondary)]"
           accentClass="text-[var(--im-color-secondary)]"
-          className={cn(mobilePane === "right" ? "flex" : "hidden md:flex")}
+          className={mobilePane === "right" ? "flex" : "hidden md:flex"}
           clinics={sortedClinics}
           selectedId={rightId}
           disabledId={leftId}

--- a/components/istanbulmedic-connect/comparison/CompareClinicPage.tsx
+++ b/components/istanbulmedic-connect/comparison/CompareClinicPage.tsx
@@ -138,6 +138,7 @@ function ComparePane({
   label,
   headerBg,
   accentClass,
+  className,
   clinics,
   selectedId,
   disabledId,
@@ -148,6 +149,7 @@ function ComparePane({
   label: string
   headerBg: string
   accentClass: string
+  className?: string
   clinics: ClinicListItem[]
   selectedId: string | null
   disabledId: string | null
@@ -159,7 +161,7 @@ function ComparePane({
   const SelectedView = SOURCE_VIEWS[source]
 
   return (
-    <div className="flex flex-col rounded-2xl border border-border/60 overflow-hidden bg-[#FEFCF8]">
+    <div className={cn("flex flex-col rounded-2xl border border-border/60 overflow-hidden bg-[#FEFCF8]", className)}>
       <div className={cn("shrink-0 px-4 py-3", headerBg)}>
         <p className="text-xs font-semibold uppercase tracking-widest text-white/70">{label}</p>
         <p className={cn(merriweather.className, "mt-0.5 truncate text-base font-bold text-white leading-snug")}>
@@ -199,14 +201,19 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
 
   const [leftId,  setLeftId]  = useState<string | null>(searchParams.get("left")  ?? null)
   const [rightId, setRightId] = useState<string | null>(searchParams.get("right") ?? null)
+  const [mobilePane, setMobilePane] = useState<"left" | "right">("left")
   const isMounted = useRef(false)
 
-  // Scroll to top instantly on mount. The root layout always renders a Footer
+  // Scroll to top on mount. The root layout always renders a Footer
   // below this component, making the body taller than 100vh and leaving the
   // window scroll position from the previous page intact on navigation.
-  // The html element also has scroll-smooth, so we force instant behaviour.
+  // Use the numeric overload for broad mobile Safari compatibility.
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'instant' })
+    try {
+      window.scrollTo(0, 0)
+    } catch {
+      // Ignore scroll API failures so page interactivity remains intact.
+    }
   }, [])
   const rawSort = searchParams.get("sort")
   const [sortBy, setSortBy] = useState<"A-Z" | "Z-A" | "Highest Rated" | "Lowest Rated">(
@@ -264,6 +271,9 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
     router.push(`${target.route}${qs ? `?${qs}` : ""}`)
   }
 
+  const leftClinic = sortedClinics.find(c => c.id === leftId) ?? null
+  const rightClinic = sortedClinics.find(c => c.id === rightId) ?? null
+
   return (
     <div className="flex flex-col bg-background overflow-hidden" style={{ height: "calc(100vh - 80px)" }}>
 
@@ -271,7 +281,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
       <div className="shrink-0 border-b border-border/60 bg-white shadow-sm">
         <div className="mx-auto max-w-7xl px-4 py-3 flex flex-wrap items-center justify-between gap-3">
           {/* Source pills */}
-          <div className="flex items-center gap-2">
+          <div className="flex max-w-full items-center gap-2 overflow-x-auto pb-1">
             {SOURCES.map(s => (
               <button
                 key={s.id}
@@ -286,6 +296,41 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
                 {s.label}
               </button>
             ))}
+          </div>
+
+          <div className="flex w-full rounded-lg border border-border/60 bg-muted/30 p-1 md:hidden" aria-label="Choose comparison clinic">
+            <button
+              type="button"
+              aria-pressed={mobilePane === "left"}
+              onClick={() => setMobilePane("left")}
+              className={cn(
+                "min-w-0 flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                mobilePane === "left"
+                  ? "bg-white text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <span className="block truncate">Clinic A</span>
+              <span className="block truncate text-[11px] font-normal opacity-75">
+                {leftClinic?.name ?? "Select a clinic"}
+              </span>
+            </button>
+            <button
+              type="button"
+              aria-pressed={mobilePane === "right"}
+              onClick={() => setMobilePane("right")}
+              className={cn(
+                "min-w-0 flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                mobilePane === "right"
+                  ? "bg-white text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <span className="block truncate">Clinic B</span>
+              <span className="block truncate text-[11px] font-normal opacity-75">
+                {rightClinic?.name ?? "Select a clinic"}
+              </span>
+            </button>
           </div>
 
           <div className="flex items-center gap-3">
@@ -317,13 +362,13 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
 
       {/* ── Split panes ─────────────────────────────────────────── */}
       <div
-        className="flex-1 min-h-0 mx-auto w-full max-w-7xl px-4 pt-3 pb-3 grid gap-4"
-        style={{ gridTemplateColumns: "1fr 1fr" }}
+        className="grid flex-1 min-h-0 w-full max-w-7xl gap-4 px-4 pt-3 pb-3 mx-auto grid-cols-1 md:grid-cols-2"
       >
         <ComparePane
           label="Clinic A"
           headerBg="bg-[var(--im-color-primary)]"
           accentClass="text-[var(--im-color-primary)]"
+          className={cn(mobilePane === "left" ? "flex" : "hidden md:flex")}
           clinics={sortedClinics}
           selectedId={leftId}
           disabledId={rightId}
@@ -335,6 +380,7 @@ export function CompareClinicPage({ clinics, source }: CompareClinicPageProps) {
           label="Clinic B"
           headerBg="bg-[var(--im-color-secondary)]"
           accentClass="text-[var(--im-color-secondary)]"
+          className={cn(mobilePane === "right" ? "flex" : "hidden md:flex")}
           clinics={sortedClinics}
           selectedId={rightId}
           disabledId={leftId}

--- a/tests/components/ComparisonViews.test.tsx
+++ b/tests/components/ComparisonViews.test.tsx
@@ -289,8 +289,8 @@ describe('CompareClinicPage — mobile switcher', () => {
     )
     render(<CompareClinicPage clinics={[baseClinic]} source="all" />)
 
-    const clinicA = screen.getByRole('button', { name: /clinic a/i })
-    const clinicB = screen.getByRole('button', { name: /clinic b/i })
+    const clinicA = screen.getByRole('button', { name: /switch to clinic a/i })
+    const clinicB = screen.getByRole('button', { name: /switch to clinic b/i })
 
     expect(clinicA).toHaveAttribute('aria-pressed', 'true')
     expect(clinicB).toHaveAttribute('aria-pressed', 'false')

--- a/tests/components/ComparisonViews.test.tsx
+++ b/tests/components/ComparisonViews.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ClinicListItem } from '@/lib/api/clinics'
 
 // ── Shared mocks ─────────────────────────────────────────────────────────────
@@ -271,6 +271,34 @@ describe('CompareClinicPage — ClinicRow score pill', () => {
   it('shows — when score is null for the active source', async () => {
     await renderRow({ ...baseClinic, googleScore: null }, 'google_places')
     expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+})
+
+// ── Mobile clinic switcher ───────────────────────────────────────────────────
+
+describe('CompareClinicPage — mobile switcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetParam.mockReset()
+    mockGetParam.mockReturnValue(null)
+  })
+
+  it('lets small-screen users switch between Clinic A and Clinic B panes', async () => {
+    const { CompareClinicPage } = await import(
+      '@/components/istanbulmedic-connect/comparison/CompareClinicPage'
+    )
+    render(<CompareClinicPage clinics={[baseClinic]} source="all" />)
+
+    const clinicA = screen.getByRole('button', { name: /clinic a/i })
+    const clinicB = screen.getByRole('button', { name: /clinic b/i })
+
+    expect(clinicA).toHaveAttribute('aria-pressed', 'true')
+    expect(clinicB).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(clinicB)
+
+    expect(clinicA).toHaveAttribute('aria-pressed', 'false')
+    expect(clinicB).toHaveAttribute('aria-pressed', 'true')
   })
 })
 


### PR DESCRIPTION
PR Description

Adds a mobile-friendly layout for the clinic comparison page. On smaller screens, users can now switch between Clinic A and Clinic B using a toggle instead of seeing both comparison columns squeezed side by side. Desktop comparison behavior stays unchanged.

Changes

Added mobile Clinic A / Clinic B switcher to the comparison page.
Shows one clinic pane at a time on small screens.
Keeps the two-column comparison layout on desktop.
Added test coverage for the mobile switcher behavior.
Automated Testing

npm test -- tests/components/ComparisonViews.test.tsx
npm run build

Manual Testing

Run:
npm run build
npm run start
Open the site on a phone using your computer’s local network IP. (http://YOUR_IP:3000)
Go to the clinic dashboard.
Select clinics to compare and open the comparison page.
Confirm that on mobile, only one clinic comparison pane is shown at a time.
Tap Clinic A and Clinic B and confirm the visible comparison switches correctly.
Confirm sorting and source controls still work on mobile.
Confirm desktop still shows both clinic comparison panes side by side.